### PR TITLE
feat(platforms.droid): fixing build and startup issues

### DIFF
--- a/Bluetooth.Maui.Platforms.Droid/AndroidBluetoothAdapter.cs
+++ b/Bluetooth.Maui.Platforms.Droid/AndroidBluetoothAdapter.cs
@@ -8,7 +8,7 @@ namespace Bluetooth.Maui.Platforms.Droid;
 public class AndroidBluetoothAdapter : BaseBluetoothAdapter
 {
     /// <inheritdoc />
-    protected AndroidBluetoothAdapter(IBluetoothManagerWrapper bluetoothManagerWrapper, IBluetoothAdapterWrapper bluetoothAdapterWrapper, ILogger<IBluetoothAdapter>? logger = null) : base(logger)
+    public AndroidBluetoothAdapter(IBluetoothManagerWrapper bluetoothManagerWrapper, IBluetoothAdapterWrapper bluetoothAdapterWrapper, ILogger<IBluetoothAdapter>? logger = null) : base(logger)
     {
         BluetoothManagerWrapper = bluetoothManagerWrapper;
         BluetoothAdapterWrapper = bluetoothAdapterWrapper;

--- a/Bluetooth.Maui.Platforms.Droid/Bluetooth.Maui.Platforms.Droid.csproj
+++ b/Bluetooth.Maui.Platforms.Droid/Bluetooth.Maui.Platforms.Droid.csproj
@@ -22,7 +22,7 @@
 
     <!-- ==================== TARGET FRAMEWORKS ==================== -->
     <PropertyGroup>
-        <TargetFramework>net10.0-android36.1</TargetFramework>
+        <TargetFramework>net10.0-android</TargetFramework>
     </PropertyGroup>
 
     <!-- ==================== PACKAGING ==================== -->

--- a/Bluetooth.Maui.Platforms.Droid/Scanning/AndroidBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Droid/Scanning/AndroidBluetoothScanner.cs
@@ -281,7 +281,7 @@ public class AndroidBluetoothScanner : BaseBluetoothScanner, ScanCallbackProxy.I
     /// <inheritdoc />
     protected override IBluetoothRemoteDevice NativeCreateDeviceFromAdvertisement(IBluetoothAdvertisement advertisement)
     {
-        var spec = new IBluetoothRemoteDeviceFactory.BluetoothRemoteDeviceFactorySpec(advertisement);
+        var spec = new AndroidBluetoothRemoteDeviceFactorySpec(advertisement);
         return _deviceFactory.Create(this, spec);
     }
 

--- a/Bluetooth.Maui/Bluetooth.Maui.csproj
+++ b/Bluetooth.Maui/Bluetooth.Maui.csproj
@@ -22,7 +22,7 @@
 
     <!-- ==================== TARGET FRAMEWORKS ==================== -->
     <PropertyGroup>
-        <TargetFrameworks>net10.0;net10.0-android36.1</TargetFrameworks>
+        <TargetFrameworks>net10.0;net10.0-android</TargetFrameworks>
         <TargetFrameworks>$(TargetFrameworks);net10.0-maccatalyst</TargetFrameworks>
         <TargetFrameworks>$(TargetFrameworks);net10.0-ios</TargetFrameworks>
         <TargetFrameworks>$(TargetFrameworks);net10.0-windows10.0.22621.0</TargetFrameworks>


### PR DESCRIPTION
## Summary

Makes the Android Bluetooth adapter constructor public to improve accessibility and usage.  
Updates target framework identifiers for Android projects by removing specific version suffixes for simplification.  
Adopts an Android-specific device factory spec for creating remote devices from advertisements to better align with platform requirements.

## Why

The constructor visibility change enables external components to instantiate the adapter directly.  
Simplifying target frameworks reduces maintenance overhead and potential compatibility issues with specific platform versions.  
Using an Android-specific device specification improves device creation accuracy and platform integration.

## Scope

- Platform: Android

## Behavior Changes

- Public API changed (constructor visibility increased)  
- Internal logic uses Android-specific factory spec for remote device creation  
- Project targets updated, potentially affecting build configurations

## Risks

Low risk: changes are mostly accessibility and build configuration updates.  
Factory spec update may affect device instantiation but limited to platform-specific code.

## Validation

Not run

## Follow-ups

- Verify external usages of the adapter to ensure compatibility with the new constructor visibility  
- Monitor build and deployment to confirm target framework changes do not introduce issues