### PR TITLE
fix(windows): validate advertisement type in device creation from advertisement and create proper factorySpec

### DIFF
--- a/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs
@@ -162,7 +162,14 @@ public class WindowsBluetoothScanner : BaseBluetoothScanner, NativeObjects.Bluet
     /// <inheritdoc />
     protected override IBluetoothRemoteDevice NativeCreateDeviceFromAdvertisement(IBluetoothAdvertisement advertisement)
     {
-        var spec = new IBluetoothRemoteDeviceFactory.BluetoothRemoteDeviceFactorySpec(advertisement);
+        ArgumentNullException.ThrowIfNull(advertisement);
+
+        if (advertisement is not WindowsBluetoothAdvertisement windowsAd)
+        {
+            throw new ArgumentException($"Expected advertisement of type {typeof(WindowsBluetoothAdvertisement)}, but got {advertisement.GetType()}", nameof(advertisement));
+        }
+
+        var spec = new WindowsBluetoothRemoteDeviceFactorySpec(windowsAd);
         return _deviceFactory.Create(this, spec);
     }
 


### PR DESCRIPTION
## Summary

validate advertisement type in device creation from advertisement and create proper factorySpec

## Why

Scanner threw errors on windows

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (`refa`)
- [ ] Docs only
- [ ] CI/build/tooling

## Affected Areas

- [ ] Abstractions
- [ ] Core
- [ ] Platform: Android
- [ ] Platform: iOS/macOS
- [x] Platform: Windows
- [ ] Platform: DotNetCore fallback
- [ ] Facade (`Bluetooth.Maui`)
- [ ] Documentation

## Behavior And Compatibility

- [ ] Public API changed
- [ ] Exception behavior changed
- [ ] DI registration behavior changed
- [ ] Capability matrix impact
- [x] No externally visible behavior change

If any box above is checked, describe impact:

Scanner threw exception when running on windows
<img width="1690" height="1047" alt="image" src="https://github.com/user-attachments/assets/581819b1-868f-4fb1-8b08-246b13876028" />

## Platform Notes

List platform-specific behavior differences introduced or touched.

## Tests

- [ ] Unit tests added/updated
- [ ] Integration/smoke tests added/updated
- [ ] Manual platform validation performed
- [ ] Not applicable (explain)

Validation notes:

## Documentation

- [ ] Docs updated in same PR
- [ ] Capability claims verified against implementation
- [ ] Links validated
- [ ] Not applicable (explain)

## Logging / Diagnostics

- [ ] New logs added
- [ ] EventId range validated
- [ ] No logging changes

## Risks And Follow-ups

Risk level:
- [x] Low
- [ ] Medium
- [ ] High

Known limitations or deferred follow-ups:
-

## Checklist

- [ ] I reviewed [Docs/Best-Practices/Contribution-DoD.md](../Docs/Best-Practices/Contribution-DoD.md)
- [ ] Commit header follows `type (scope): short imperative` and is <= 72 chars
- [ ] Commit type is one of: feat, fix, refa, perf, docs, ci, chore, test, build
- [ ] Commit body is 1-2 factual sentences (what/why), no emojis, refs, or co-authors
- [ ] If architectural behavior changed, an ADR was added or updated under [Docs/Architecture/ADR](../Docs/Architecture/ADR/README.md)
