### PR TITLE
feat(scanning): add CleanRestartScanningAsync for DFU reboot recovery

### DIFF
--- a/Bluetooth.Abstractions.Scanning/IBluetoothScanner.StartStop.cs
+++ b/Bluetooth.Abstractions.Scanning/IBluetoothScanner.StartStop.cs
@@ -120,7 +120,7 @@ public partial interface IBluetoothScanner
     ///     defaults if the scanner was not running.
     /// </param>
     /// <param name="permissionOptions">The options for requesting permissions. If null, default options will be used.</param>
-    /// <param name="timeout">The timeout applied to the stop and the start leg individually.</param>
+    /// <param name="timeout">The timeout applied to the stop and the start leg individually. Does not bound the registry-clear step in between.</param>
     /// <param name="cancellationToken">A cancellation token to cancel this operation.</param>
     /// <returns>A task that represents the asynchronous clean restart operation.</returns>
     /// <remarks>

--- a/Bluetooth.Abstractions.Scanning/IBluetoothScanner.StartStop.cs
+++ b/Bluetooth.Abstractions.Scanning/IBluetoothScanner.StartStop.cs
@@ -106,4 +106,49 @@ public partial interface IBluetoothScanner
 
     #endregion
 
+    #region Clean Restart
+
+    /// <summary>
+    ///     Stops the scanner, discards every device in the scanner's registry, then starts scanning again.
+    /// </summary>
+    /// <param name="newAdvertisementFilter">
+    ///     An optional replacement for <see cref="AdvertisementFilter" />, applied while the scanner is stopped so it is
+    ///     already in effect when scanning resumes. When null the current filter is left untouched.
+    /// </param>
+    /// <param name="scanningOptions">
+    ///     The options to restart with. When null the options of the scan session being restarted are reused, falling back to
+    ///     defaults if the scanner was not running.
+    /// </param>
+    /// <param name="permissionOptions">The options for requesting permissions. If null, default options will be used.</param>
+    /// <param name="timeout">The timeout applied to the stop and the start leg individually.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel this operation.</param>
+    /// <returns>A task that represents the asynchronous clean restart operation.</returns>
+    /// <remarks>
+    ///     <para>
+    ///         Unlike <see cref="StopScanningAsync" /> followed by <see cref="StartScanningAsync" />, this also drops the
+    ///         device registry, so devices discovered before the restart are gone: every device is disconnected, removed and
+    ///         disposed. Hold on to device identifiers rather than <see cref="IBluetoothRemoteDevice" /> instances across a
+    ///         clean restart, and re-acquire the instance afterwards with <see cref="WaitForDeviceToAppearAsync(string, TimeSpan?, CancellationToken)" />.
+    ///     </para>
+    ///     <para>
+    ///         The intended use case is a device that changes identity while the scanner is running - most notably a device
+    ///         rebooting into or out of firmware-update mode, where a stale registry entry and an in-flight scan session
+    ///         otherwise prevent it from being rediscovered under its new advertisement.
+    ///     </para>
+    ///     <para>
+    ///         Restarting a scanner that is already stopped is valid: the stop leg is skipped and the registry is still dropped.
+    ///     </para>
+    /// </remarks>
+    /// <exception cref="ScannerFailedToStopException">Thrown when the scanner fails to stop.</exception>
+    /// <exception cref="ScannerFailedToStartException">Thrown when the scanner fails to start again.</exception>
+    /// <exception cref="TimeoutException">Thrown when either leg of the operation times out.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled.</exception>
+    Task CleanRestartScanningAsync(Func<IBluetoothAdvertisement, bool>? newAdvertisementFilter = null,
+        ScanningOptions? scanningOptions = null,
+        PermissionOptions? permissionOptions = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default);
+
+    #endregion
+
 }

--- a/Bluetooth.Core.Scanning/BaseBluetoothScanner.Logging.cs
+++ b/Bluetooth.Core.Scanning/BaseBluetoothScanner.Logging.cs
@@ -60,5 +60,9 @@ public abstract partial class BaseBluetoothScanner
         Message = "Error checking scanner permissions")]
     partial void LogScannerPermissionCheckFailed(Exception exception);
 
+    [LoggerMessage(EventId = 115, Level = LogLevel.Information,
+        Message = "Scanner clean restarting, dropping the device registry")]
+    partial void LogScannerCleanRestarting();
+
     #endregion
 }

--- a/Bluetooth.Core.Scanning/BaseBluetoothScanner.StartStop.cs
+++ b/Bluetooth.Core.Scanning/BaseBluetoothScanner.StartStop.cs
@@ -389,4 +389,32 @@ public abstract partial class BaseBluetoothScanner
 
     #endregion
 
+    #region Clean Restart
+
+    /// <inheritdoc />
+    public async virtual Task CleanRestartScanningAsync(Func<IBluetoothAdvertisement, bool>? newAdvertisementFilter = null,
+        ScanningOptions? scanningOptions = null,
+        PermissionOptions? permissionOptions = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        LogScannerCleanRestarting();
+
+        scanningOptions ??= ActiveScanningOptions; // captured before stopping, which clears it
+
+        await StopScanningIfNeededAsync(timeout, cancellationToken).ConfigureAwait(false);
+
+        // must come after the stop, otherwise the in-flight scan repopulates the registry as we drain it
+        await ClearDevicesAsync().ConfigureAwait(false);
+
+        if (newAdvertisementFilter != null)
+        {
+            AdvertisementFilter = newAdvertisementFilter;
+        }
+
+        await StartScanningAsync(scanningOptions, permissionOptions, timeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion
+
 }

--- a/Bluetooth.Maui/BluetoothScanner.cs
+++ b/Bluetooth.Maui/BluetoothScanner.cs
@@ -360,6 +360,22 @@ public class BluetoothScanner : IBluetoothScanner, IAsyncDisposable
         await _platformScanner.StopScanningIfNeededAsync(timeout, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
+    public async Task CleanRestartScanningAsync(
+        Func<IBluetoothAdvertisement, bool>? newAdvertisementFilter = null,
+        ScanningOptions? scanningOptions = null,
+        Abstractions.Scanning.Options.PermissionOptions? permissionOptions = null,
+        TimeSpan? timeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        await _platformScanner.CleanRestartScanningAsync(
+            newAdvertisementFilter,
+            scanningOptions,
+            permissionOptions,
+            timeout,
+            cancellationToken).ConfigureAwait(false);
+    }
+
     #endregion
 
     #region IBluetoothScanner Implementation - Permissions

--- a/Docs/API-Reference/Abstractions.md
+++ b/Docs/API-Reference/Abstractions.md
@@ -161,6 +161,14 @@ ValueTask StopScanningIfNeededAsync(
     TimeSpan? timeout = null,
     CancellationToken cancellationToken = default);
 
+// Stop, drop the device registry, start again
+Task CleanRestartScanningAsync(
+    Func<IBluetoothAdvertisement, bool>? newAdvertisementFilter = null,
+    ScanningOptions? scanningOptions = null,
+    PermissionOptions? permissionOptions = null,
+    TimeSpan? timeout = null,
+    CancellationToken cancellationToken = default);
+
 // Runtime configuration
 ValueTask UpdateScannerOptionsAsync(
     ScanningOptions options,

--- a/Docs/Core-Concepts/Scanner.md
+++ b/Docs/Core-Concepts/Scanner.md
@@ -217,6 +217,32 @@ await scanner.StartScanningIfNeededAsync();
 await scanner.StopScanningIfNeededAsync();
 ```
 
+### Clean Restart
+
+`CleanRestartScanningAsync` stops the scanner, discards every device in the registry, then starts scanning again:
+
+```csharp
+await scanner.CleanRestartScanningAsync();
+```
+
+Use it when a device changes identity while the scanner is running - typically a device rebooting into or out of
+firmware-update mode, where a stale registry entry plus an in-flight scan session stop it from being rediscovered under
+its new advertisement. It also accepts a replacement advertisement filter, applied while the scanner is stopped so it is
+already in effect when scanning resumes:
+
+```csharp
+await scanner.CleanRestartScanningAsync(ad => ad.DeviceName.Contains("DfuTarg"));
+```
+
+Every device is disconnected, removed and disposed, so `IBluetoothRemoteDevice` instances do not survive the restart.
+Keep the device id instead and re-acquire the instance afterwards:
+
+```csharp
+var deviceId = device.Id;
+await scanner.CleanRestartScanningAsync();
+device = await scanner.WaitForDeviceToAppearAsync(deviceId, TimeSpan.FromSeconds(30));
+```
+
 ### Timeouts and Cancellation
 
 All operations support timeouts and cancellation:


### PR DESCRIPTION
## Summary
- Ports `CleanRestartAsync` from the legacy Laerdal.Ble scanner (`Scanner.StartStop.cs`) as `CleanRestartScanningAsync` on `IBluetoothScanner`
- Stop -> drop registry -> optional filter swap -> restart, matching legacy sequencing (no artificial delay; relies on `StopScanningAsync` awaiting `IsRunning == false`)
- Needed to rediscover Laerdal devices after a DFU-induced reboot (app<->bootloader)

## Review notes (carried over from implementation report)
- `ClearDeviceAsync` disposes devices, unlike legacy's non-disposing `CleanAsync` — known follow-up needed when the DFU RunAsync-equivalent is ported (a freshly-rediscovered device must not be disposed by this same call). Tracked in project context, not yet a blocking issue since that flow isn't ported.
- No platform-specific implementation needed — cross-platform code, only the *decision* to call it is Android-specific in DFU call sites.
- No test project exists in this repo; verified via clean build across net10.0/-android/-ios (0 warnings/errors).

🤖 Generated with a Claude Code agent team (laerdal-ble-engineer / ble-plugin-engineer workflow)