### PR TITLE
feat(scanning): add IsSignalStrengthProbingEnabled toggle on remote devices

### DIFF
--- a/Bluetooth.Abstractions.Scanning/IBluetoothRemoteDevice.SignalStrength.cs
+++ b/Bluetooth.Abstractions.Scanning/IBluetoothRemoteDevice.SignalStrength.cs
@@ -16,6 +16,21 @@ public partial interface IBluetoothRemoteDevice
     double SignalStrengthPercent { get; }
 
     /// <summary>
+    ///     Gets or sets a value indicating whether this device may be probed for its signal strength. Defaults to <c>true</c>.
+    ///     When set to <c>false</c>, <see cref="ReadSignalStrengthAsync" /> stops issuing native RSSI reads and returns the
+    ///     last known <see cref="SignalStrengthDbm" /> instead.
+    /// </summary>
+    /// <remarks>
+    ///     Set this to <c>false</c> before starting a firmware update. Nordic's DFU bootloader tends to drop the connection
+    ///     when it is spammed with RSSI reads, which is particularly dangerous while an update is in flight. A read that is
+    ///     already in flight when this is set to <c>false</c> still completes normally.
+    ///     <para>
+    ///         Signal strengths carried by advertisements are unaffected — those are passive and cost the device nothing.
+    ///     </para>
+    /// </remarks>
+    bool IsSignalStrengthProbingEnabled { get; set; }
+
+    /// <summary>
     ///     Reads the signal strength asynchronously.
     ///     This is an operation running on a ticker when the device is connected.
     ///     We can't get that value from advertisement anymore.
@@ -40,6 +55,10 @@ public partial interface IBluetoothRemoteDevice
     ///         - Accuracy varies by platform and hardware capabilities
     ///     </para>
     ///     <para>Call frequency should be limited to avoid impacting performance - recommended interval: 1-5 seconds.</para>
+    ///     <para>
+    ///         Returns the last known <see cref="SignalStrengthDbm" /> without touching the radio when
+    ///         <see cref="IsSignalStrengthProbingEnabled" /> is <c>false</c>.
+    ///     </para>
     /// </remarks>
     ValueTask<int> ReadSignalStrengthAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default);
 }

--- a/Bluetooth.Abstractions.Scanning/IBluetoothRemoteDevice.SignalStrength.cs
+++ b/Bluetooth.Abstractions.Scanning/IBluetoothRemoteDevice.SignalStrength.cs
@@ -28,7 +28,7 @@ public partial interface IBluetoothRemoteDevice
     ///         Signal strengths carried by advertisements are unaffected — those are passive and cost the device nothing.
     ///     </para>
     /// </remarks>
-    bool IsSignalStrengthProbingEnabled { get; set; }
+    bool IsSignalStrengthProbingEnabled { get => true; set { } }
 
     /// <summary>
     ///     Reads the signal strength asynchronously.

--- a/Bluetooth.Core.Scanning/BaseBluetoothRemoteDevice.Logging.cs
+++ b/Bluetooth.Core.Scanning/BaseBluetoothRemoteDevice.Logging.cs
@@ -108,5 +108,10 @@ public abstract partial class BaseBluetoothRemoteDevice
     [LoggerMessage(EventId = 249, Level = LogLevel.Information,
         Message = "  Service: {ServiceId}")]
     partial void LogServiceFound(Guid serviceId);
+
+    // Signal strength (260-269)
+    [LoggerMessage(EventId = 260, Level = LogLevel.Debug,
+        Message = "Device {DeviceId} signal strength read skipped (IsSignalStrengthProbingEnabled was false)")]
+    partial void LogSignalStrengthProbingSkipped(string deviceId);
     #endregion
 }

--- a/Bluetooth.Core.Scanning/BaseBluetoothRemoteDevice.SignalStrength.cs
+++ b/Bluetooth.Core.Scanning/BaseBluetoothRemoteDevice.SignalStrength.cs
@@ -7,6 +7,12 @@ public abstract partial class BaseBluetoothRemoteDevice
     /// <inheritdoc />
     public async ValueTask<int> ReadSignalStrengthAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
+        if (!IsSignalStrengthProbingEnabled)
+        {
+            LogSignalStrengthProbingSkipped(Id);
+            return SignalStrengthDbm;
+        }
+
         // Prevents multiple calls to ReadValueAsync, if already reading signal strength, we merge the calls
         if (SignalStrengthReadingTcs is { Task.IsCompleted: false })
         {
@@ -54,6 +60,9 @@ public abstract partial class BaseBluetoothRemoteDevice
     #region Properties
 
     private readonly ConcurrentQueue<int> _rssiHistory = new ConcurrentQueue<int>();
+
+    /// <inheritdoc />
+    public bool IsSignalStrengthProbingEnabled { get; set; } = true;
 
     /// <inheritdoc />
     public int SignalStrengthDbm

--- a/Bluetooth.Maui/BluetoothRemoteDevice.cs
+++ b/Bluetooth.Maui/BluetoothRemoteDevice.cs
@@ -478,6 +478,13 @@ public class BluetoothRemoteDevice : IBluetoothRemoteDevice
     public double SignalStrengthPercent => _platformDevice.SignalStrengthPercent;
 
     /// <inheritdoc />
+    public bool IsSignalStrengthProbingEnabled
+    {
+        get => _platformDevice.IsSignalStrengthProbingEnabled;
+        set => _platformDevice.IsSignalStrengthProbingEnabled = value;
+    }
+
+    /// <inheritdoc />
     public ValueTask<int> ReadSignalStrengthAsync(
         TimeSpan? timeout = null,
         CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Ports the legacy `IsForcedSignalStrengthUpdatingWhileConnectedEnabled` concept from Laerdal.Ble as `IsSignalStrengthProbingEnabled` on `IBluetoothRemoteDevice`
- Lets callers pause/resume RSSI probing while connected — needed during DFU, since some bootloaders (e.g. Laerdal CprMeter2-class devices) drop the connection if spammed with signal-strength reads mid-update

🤖 Generated with a Claude Code agent team (ble-plugin-engineer)