### PR TITLE
fix(scanning): resolve DeviceWrapper devices to their platform delegate; fix disconnect-path bugs

### DIFF
--- a/Bluetooth.Maui.Platforms.Apple/Scanning/AppleBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Apple/Scanning/AppleBluetoothScanner.cs
@@ -221,9 +221,14 @@ public class AppleBluetoothScanner : BaseBluetoothScanner, CbCentralManagerWrapp
 
     private static bool AreRepresentingTheSameObject(CBPeripheral peripheral, IBluetoothRemoteDevice device)
     {
+        // Identifier alone is the correct, sufficient identity check - CoreBluetooth assigns a stable
+        // UUID per remembered peripheral. Do NOT also require the native object handle to match: a
+        // peripheral retrieved via a fresh connect/reconnect/state-restoration path can be a different
+        // CBPeripheral instance with the same identifier, which previously made this method return
+        // false for the exact same physical peripheral and caused GetDevice() to throw
+        // DeviceNotFoundException on ordinary connect/disconnect callbacks.
         return device is AppleBluetoothRemoteDevice sharedDevice
-            && sharedDevice.CbPeripheralWrapper.CbPeripheral.Identifier.Equals(peripheral.Identifier)
-            && sharedDevice.CbPeripheralWrapper.CbPeripheral.Handle.Handle == peripheral.Handle.Handle;
+            && sharedDevice.CbPeripheralWrapper.CbPeripheral.Identifier.Equals(peripheral.Identifier);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Three related bugs found and fixed via a real end-to-end DFU install against physical Little hardware in the FDS mobile app - all surfaced during ordinary connect/disconnect on iOS, none of them DFU-specific in cause.

1. **`GetDevice(CBPeripheral)` threw `DeviceNotFoundException` even on a matching identifier.** It cast the matched device directly to `ICbPeripheralDelegate`, but a scanner `DeviceWrapper` substituting a custom subtype (the library's own documented extensibility mechanism, e.g. `Bluetooth.Maui.BluetoothRemoteDevice`) is never itself an `AppleBluetoothRemoteDevice` - the cast always failed for any wrapped device, regardless of identity matching. Also fixed the identity check itself: it required the native `CBPeripheral` object *handle* to match in addition to the identifier, which fails whenever CoreBluetooth vends a fresh object for an already-known peripheral (connect/reconnect/state-restoration) - identifier alone is CoreBluetooth's own stable, sufficient identity.
   - Added `IBluetoothRemoteDevice.UnderlyingPlatformDevice` (default interface member, defaults to `this`) so wrapper types can delegate to the platform device they wrap. `BluetoothRemoteDevice` overrides it recursively. `GetDevice()` resolves through this before casting.
2. **`AppleNativeBluetoothException`'s constructor threw `ArgumentNullException`** from `string.Join(";", nsError.LocalizedRecoveryOptions)` whenever `LocalizedRecoveryOptions` was null - true for the vast majority of `NSError`s. Constructing the exception itself threw for almost any native error, including an ordinary "peripheral disconnected from us" during a DFU-triggered reboot.
3. **`OnDisconnect()` unconditionally logged `"{DeviceId} failed to disconnect"` at ERROR** for any disconnect with an associated exception, *before* checking `IgnoreNextUnexpectedDisconnection` - so that flag never suppressed this specific log line, only a separate event/log further downstream. Every DFU-triggered reboot (or any other expected mid-session disconnect) logged as an ERROR regardless of the flag. Restructured so the unexpected-disconnection path defers entirely to `OnUnexpectedDisconnection()`, which already had correct ignored-vs-warning logic.

No equivalent extra check exists on the Android scanner for (1) - confirmed this isn't platform-parity, just defensive checks that were never needed. (3) is in shared cross-platform code (`Bluetooth.Core.Scanning`), so it also fixes Android/Windows.

## Test plan
- [x] `dotnet build -f net10.0-ios -r ios-arm64` and `-f net10.0-android` succeed
- [x] Real Little DFU install completes end-to-end via FDS mobile app's Dev Mode test harness, using this fix via a temporary local `ProjectReference` - progress reports correctly 0-100%, no more `DeviceNotFoundException` crash, no more spurious ERROR-level disconnect logging for the expected DFU-reboot disconnect