### PR TITLE
fix(android): only request legacy BLUETOOTH permission below API 31

### DIFF
--- a/Bluetooth.Maui.Platforms.Droid/Broadcasting/AndroidBluetoothBroadcaster.cs
+++ b/Bluetooth.Maui.Platforms.Droid/Broadcasting/AndroidBluetoothBroadcaster.cs
@@ -297,14 +297,19 @@ public class AndroidBluetoothBroadcaster : BaseBluetoothBroadcaster, AdvertiseCa
     /// </remarks>
     protected async override ValueTask NativeRequestBroadcasterPermissionsAsync(CancellationToken cancellationToken)
     {
-        await AndroidBluetoothPermissions.BluetoothPermission.RequestIfNeededAsync().ConfigureAwait(false);
-
         // For API 31+ (Android 12+), spec BLUETOOTH_ADVERTISE only (not CONNECT)
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
         {
             await AndroidBluetoothPermissions.BluetoothAdvertisePermission.RequestIfNeededAsync().ConfigureAwait(false);
             return;
         }
+
+        // Legacy BLUETOOTH permission only applies below API 31 - on API 31+ it's superseded by
+        // BLUETOOTH_ADVERTISE/CONNECT, and the OS elides it from the installed package's reported
+        // permission list for apps targeting SDK 31+. Requesting it unconditionally makes
+        // Permissions.BasePlatformPermission.CheckStatusAsync() falsely report it as "not declared in
+        // AndroidManifest.xml" even when it is - see the matching fix in AndroidBluetoothScanner.
+        await AndroidBluetoothPermissions.BluetoothPermission.RequestIfNeededAsync().ConfigureAwait(false);
 
         // For older versions, no special permissions needed
     }

--- a/Bluetooth.Maui.Platforms.Droid/Broadcasting/AndroidBluetoothBroadcaster.cs
+++ b/Bluetooth.Maui.Platforms.Droid/Broadcasting/AndroidBluetoothBroadcaster.cs
@@ -297,6 +297,8 @@ public class AndroidBluetoothBroadcaster : BaseBluetoothBroadcaster, AdvertiseCa
     /// </remarks>
     protected async override ValueTask NativeRequestBroadcasterPermissionsAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         // For API 31+ (Android 12+), spec BLUETOOTH_ADVERTISE only (not CONNECT)
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
         {

--- a/Bluetooth.Maui.Platforms.Droid/Scanning/AndroidBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Droid/Scanning/AndroidBluetoothScanner.cs
@@ -396,6 +396,8 @@ public class AndroidBluetoothScanner : BaseBluetoothScanner, ScanCallbackProxy.I
     /// </remarks>
     protected async override ValueTask NativeRequestScannerPermissionsAsync(bool requireBackgroundLocation, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         // For API 31+ (Android 12+), spec BLUETOOTH_SCAN only (not CONNECT)
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
         {

--- a/Bluetooth.Maui.Platforms.Droid/Scanning/AndroidBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Droid/Scanning/AndroidBluetoothScanner.cs
@@ -396,14 +396,19 @@ public class AndroidBluetoothScanner : BaseBluetoothScanner, ScanCallbackProxy.I
     /// </remarks>
     protected async override ValueTask NativeRequestScannerPermissionsAsync(bool requireBackgroundLocation, CancellationToken cancellationToken)
     {
-        await AndroidBluetoothPermissions.BluetoothPermission.RequestIfNeededAsync().ConfigureAwait(false);
-
         // For API 31+ (Android 12+), spec BLUETOOTH_SCAN only (not CONNECT)
         if (OperatingSystem.IsAndroidVersionAtLeast(31))
         {
             await AndroidBluetoothPermissions.BluetoothScanPermission.RequestIfNeededAsync().ConfigureAwait(false);
             return;
         }
+
+        // Legacy BLUETOOTH permission only applies below API 31 - on API 31+ it's superseded by
+        // BLUETOOTH_SCAN/CONNECT, and the OS elides it from the installed package's reported permission
+        // list for apps targeting SDK 31+. Requesting it unconditionally makes
+        // Permissions.BasePlatformPermission.CheckStatusAsync() falsely report it as "not declared in
+        // AndroidManifest.xml" even when it is, crashing every scan attempt on modern Android.
+        await AndroidBluetoothPermissions.BluetoothPermission.RequestIfNeededAsync().ConfigureAwait(false);
 
         // For API 29-30 (Android 10-11), spec FINE_LOCATION and optionally BACKGROUND_LOCATION
         if (OperatingSystem.IsAndroidVersionAtLeast(29))


### PR DESCRIPTION
## Summary
- `AndroidBluetoothScanner.NativeRequestScannerPermissionsAsync` and `AndroidBluetoothBroadcaster.NativeRequestBroadcasterPermissionsAsync` both unconditionally requested the legacy `android.permission.BLUETOOTH` permission before branching on API level for the modern `BLUETOOTH_SCAN`/`BLUETOOTH_ADVERTISE` permissions.
- On API 31+, that legacy permission is superseded by `BLUETOOTH_SCAN`/`CONNECT`/`ADVERTISE`, and the OS elides it from the installed package's reported permission list for apps targeting SDK 31+ - even when it's genuinely declared in `AndroidManifest.xml`.
- `Permissions.BasePlatformPermission.CheckStatusAsync()` validates manifest declarations against that reported list, so it throws `You need to declare using the permission: android.permission.BLUETOOTH` on every request - crashing any consumer calling `RequestScannerPermissionsAsync`/`RequestBroadcasterPermissionsAsync` on real Android 12+ hardware with a high targetSdk.
- Discovered via the first real Android BLE scan attempt in `fds-mobile-app` on 2026-08-03 - a 100% reproducible crash on cold start.
- `NativeHasScannerPermissionsAsync`/`NativeHasBroadcasterPermissionsAsync` already correctly skip the legacy permission on API 31+; this brings the `Request*` counterparts in line with that existing, correct pattern.

## Test plan
- [x] `dotnet build -f net10.0-android` succeeds
- [x] Reproduced the crash on a real Samsung Galaxy S22 (Android 16, API 36) before the fix, with full inner-exception diagnostics
- [ ] End-to-end: confirm scanning works on the same device once the next published version is consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)