### PR TITLE
fix: enable back-and-forth navigation for devices, services, characteristics in sample

### DIFF
--- a/Bluetooth.Maui.Sample.Scanner/ViewModels/CharacteristicsViewModel.cs
+++ b/Bluetooth.Maui.Sample.Scanner/ViewModels/CharacteristicsViewModel.cs
@@ -75,6 +75,15 @@ public class CharacteristicsViewModel : BaseViewModel
     ///     Gets the command to select and interact with a characteristic.
     /// </summary>
     public IAsyncRelayCommand<IBluetoothRemoteCharacteristic> SelectCharacteristicCommand { get; }
+    
+    /// <summary>
+    ///     Gets or sets the currently selected Characteristic.
+    /// </summary>
+    public IBluetoothRemoteCharacteristic? SelectedCharacteristic
+    {
+        get => GetValue<IBluetoothRemoteCharacteristic?>(null);
+        set => SetValue(value);
+    }
 
     /// <summary>
     ///     Sets the service to display and manage.
@@ -135,14 +144,15 @@ public class CharacteristicsViewModel : BaseViewModel
             return;
         }
 
+        SelectedCharacteristic = null;
         _logger.LogInformation("Characteristic selected: {CharacteristicId} from service: {Id}", characteristic.Id, ServiceId);
 
-          // Navigate to the write/listen lab page with the selected characteristic
+        // Navigate to the write/listen lab page with the selected characteristic
         var parameters = new Dictionary<string, object>
         {
             ["Characteristic"] = characteristic
         };
-          await _navigation.NavigateToAsync<WriteListenLabPage>(parameters);
+        await _navigation.NavigateToAsync<WriteListenLabPage>(parameters);
     }
 
     /// <summary>

--- a/Bluetooth.Maui.Sample.Scanner/ViewModels/DeviceViewModel.cs
+++ b/Bluetooth.Maui.Sample.Scanner/ViewModels/DeviceViewModel.cs
@@ -101,6 +101,15 @@ public class DeviceViewModel : BaseViewModel
     ///     Gets the command to select and navigate to a service.
     /// </summary>
     public IAsyncRelayCommand<IBluetoothRemoteService> SelectServiceCommand { get; }
+    
+    /// <summary>
+    ///     Gets or sets the currently selected service.
+    /// </summary>
+    public IBluetoothRemoteService? SelectedService
+    {
+        get => GetValue<IBluetoothRemoteService?>(null);
+        set => SetValue(value);
+    }
 
     /// <summary>
     ///     Sets the device to display and manage.
@@ -230,6 +239,8 @@ public class DeviceViewModel : BaseViewModel
         {
             return;
         }
+
+        SelectedService = null;
 
         _logger.LogInformation("Service selected: {Id} on device: {DeviceName}", service.Id, DeviceName);
 

--- a/Bluetooth.Maui.Sample.Scanner/ViewModels/ScannerViewModel.cs
+++ b/Bluetooth.Maui.Sample.Scanner/ViewModels/ScannerViewModel.cs
@@ -58,7 +58,7 @@ public class ScannerViewModel : BaseViewModel
     public IBluetoothRemoteDevice? SelectedDevice
     {
         get => GetValue<IBluetoothRemoteDevice?>(null);
-        private set => SetValue(value);
+        set => SetValue(value);
     }
 
     /// <summary>
@@ -237,8 +237,7 @@ public class ScannerViewModel : BaseViewModel
 
         _logger.LogInformation("Device selected: {DeviceName} ({DeviceId})", device.Name ?? "Unknown", device.Id);
 
-        SelectedDevice = device;
-
+        SelectedDevice = null; // Clear selection after navigation to enable going back and forth
         // Navigate to DevicePage with the selected device
         await _navigation.NavigateToAsync<DevicePage>(new Dictionary<string, object>
         {

--- a/Bluetooth.Maui.Sample.Scanner/Views/CharacteristicsPage.xaml
+++ b/Bluetooth.Maui.Sample.Scanner/Views/CharacteristicsPage.xaml
@@ -44,6 +44,7 @@
         <CollectionView Grid.Row="1"
                         ItemsSource="{Binding Characteristics}"
                         SelectionMode="Single"
+                        SelectedItem="{Binding SelectedCharacteristic, Mode=TwoWay}"
                         SelectionChangedCommand="{Binding SelectCharacteristicCommand}"
                         SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
 

--- a/Bluetooth.Maui.Sample.Scanner/Views/DevicePage.xaml
+++ b/Bluetooth.Maui.Sample.Scanner/Views/DevicePage.xaml
@@ -78,6 +78,7 @@
                         ItemsSource="{Binding Services}"
                         SelectionMode="Single"
                         SelectionChangedCommand="{Binding SelectServiceCommand}"
+                        SelectedItem="{Binding SelectedService, Mode=TwoWay}"
                         SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">
 
             <CollectionView.EmptyView>

--- a/Bluetooth.Maui.Sample.Scanner/Views/ScannerPage.xaml
+++ b/Bluetooth.Maui.Sample.Scanner/Views/ScannerPage.xaml
@@ -118,7 +118,7 @@
         <!-- Device List -->
         <CollectionView Grid.Row="1"
                         ItemsSource="{Binding Devices}"
-                        SelectedItem="{Binding SelectedDevice, Mode=OneWay}"
+                        SelectedItem="{Binding SelectedDevice, Mode=TwoWay}"
                         SelectionMode="Single"
                         SelectionChangedCommand="{Binding SelectDeviceCommand}"
                         SelectionChangedCommandParameter="{Binding Source={RelativeSource Self}, Path=SelectedItem}">


### PR DESCRIPTION
## Summary

When selecting devices, services or characteristics, you could not go back and forth to and from the same selection. If you selected device X and then returned to the selection page, you could not select device X again, instead needed to select Y, then navigate back, then re-select X. This commit fixes that issue.

## Why

Explain the reason for this change.

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor (`refa`)
- [ ] Docs only
- [ ] CI/build/tooling

## Affected Areas

- [ ] Abstractions
- [ ] Core
- [ ] Platform: Android
- [ ] Platform: iOS/macOS
- [ ] Platform: Windows
- [ ] Platform: DotNetCore fallback
- [ ] Facade (`Bluetooth.Maui`)
- [ ] Documentation
- [x] Sample

## Behavior And Compatibility

- [ ] Public API changed
- [ ] Exception behavior changed
- [ ] DI registration behavior changed
- [ ] Capability matrix impact
- [x] No externally visible behavior change

If any box above is checked, describe impact:

## Platform Notes

List platform-specific behavior differences introduced or touched.

## Tests

- [ ] Unit tests added/updated
- [ ] Integration/smoke tests added/updated
- [ ] Manual platform validation performed
- [ ] Not applicable (explain)

Validation notes:

## Documentation

- [ ] Docs updated in same PR
- [ ] Capability claims verified against implementation
- [ ] Links validated
- [ ] Not applicable (explain)

## Logging / Diagnostics

- [ ] New logs added
- [ ] EventId range validated
- [ ] No logging changes

## Risks And Follow-ups

Risk level:
- [ ] Low
- [ ] Medium
- [ ] High

Known limitations or deferred follow-ups:
-

## Checklist

- [ ] I reviewed [Docs/Best-Practices/Contribution-DoD.md](../Docs/Best-Practices/Contribution-DoD.md)
- [ ] Commit header follows `type (scope): short imperative` and is <= 72 chars
- [ ] Commit type is one of: feat, fix, refa, perf, docs, ci, chore, test, build
- [ ] Commit body is 1-2 factual sentences (what/why), no emojis, refs, or co-authors
- [ ] If architectural behavior changed, an ADR was added or updated under [Docs/Architecture/ADR](../Docs/Architecture/ADR/README.md)
