### PR TITLE
feat (windows): merge scan-response PDUs into advertisements

### DIFF
--- a/.claude/skills/plugin-bluetooth/SKILL.md
+++ b/.claude/skills/plugin-bluetooth/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: plugin-bluetooth
+description: Use when writing, reviewing, or debugging code in this repo (the Bluetooth.Abstractions*/Bluetooth.Core*/Bluetooth.Maui* projects) — BLE scanning, GATT client/server, L2CAP, broadcasting — or when consuming the Bluetooth.Maui NuGet package and hitting platform-specific (Android/iOS/macOS/Windows) BLE behavior. Routes to this repo's existing architecture/conventions docs instead of re-deriving them, and flags native-callback bug classes that were only found through real-hardware testing and aren't written down anywhere else yet.
+---
+
+# Plugin.Bluetooth orientation
+
+Cross-platform .NET MAUI BLE library (OSS, `laerdal/Plugin.Bluetooth`). Central role
+(scanner/GATT client) + peripheral role (broadcaster/GATT server), one project per concern,
+layered Abstractions → Core → Platform (`Droid`/`Apple`/`Win`/`DotNetCore`) → `Bluetooth.Maui`
+facade. Don't re-derive any of this from scratch — it's already documented in depth in this
+repo. Verify the paths below still exist before trusting them; if they don't, this skill is
+stale, not the docs.
+
+## Step 1 — do this now, before anything else
+
+**Read `Docs/COPILOT_INSTRUCTIONS.md` in full, right now, before writing, reviewing, or
+reasoning about any non-trivial code in this repo.** That file is the single source of truth
+for architecture, naming conventions, logging/EventId ranges, exception hierarchy, options
+pattern, cancellation/TCS patterns, thread-safety rules, per-platform API guidance, and a
+60+ item code review checklist — everything below this point in this skill assumes you've
+already read it and only adds what that file doesn't cover. This mirrors what
+`.github/copilot-instructions.md` does for GitHub Copilot (it auto-loads a thin pointer to
+the same file) — you don't get that auto-load, so treat this line as your equivalent of it.
+Don't skip this because the task looks small; the file itself is what defines what "small"
+safely means here (e.g. a one-line log statement still has EventId-range and structured-
+logging rules attached to it).
+
+## Where the rest of the depth lives — read before writing code
+
+| You need | Read |
+|---|---|
+| Doc map / where anything else lives | `Docs/README.md` |
+| Architecture rules + diagrams + why the facade pattern exists | `Docs/ARCHITECTURE_GUIDELINES.md`, `Docs/ARCHITECTURE_DIAGRAMS.md`, `Docs/FACADE_PATTERN_SUMMARY.md` |
+| A past architectural decision + its alternatives | `Docs/Architecture/ADR/` — add a new ADR here if you change architectural behavior, per `CONTRIBUTING.md` |
+| Consumer-facing troubleshooting (GATT 133, permissions, scanning, notifications, MTU, platform quirks) | `Docs/Troubleshooting/Common-Issues.md`, `Docs/Troubleshooting/Debugging.md` |
+| Getting started / permissions / platform setup | `Docs/Getting-Started/` |
+| Options records (Scanning/Connection/L2CAP/Broadcasting/Infrastructure) | `Docs/Configuration/` |
+| Commit format, PR Definition of Done | `CONTRIBUTING.md`, `Docs/Best-Practices/Contribution-DoD.md` |
+
+Quick sanity checks before relying on any doc's project/API list (things move):
+
+```bash
+find . -maxdepth 1 -type d -iname "Bluetooth.*"                       # current project list
+grep -rn "protected abstract.*Native" Bluetooth.Core.Scanning/ Bluetooth.Core.Broadcasting/  # current Native* surface
+```
+
+## Native-callback bug-class watchlist
+
+Not in `Docs/Troubleshooting/` (that's consumer-facing usage issues) — this is a distinct
+class of bug in the platform-native callback plumbing itself. All of the following were silent,
+**permanent hangs with no thrown exception**, and all were found only by running real DFU
+firmware installs against physical hardware (Little Anne Mk1 on Android, real iOS device) —
+simulators/emulators didn't reproduce any of them. When writing or reviewing `Native*`
+callback code (`OnConnectionStateChange`, `OnDescriptorWrite`, TCS-completion paths, etc.),
+check whether the change could reintroduce one of these shapes:
+
+| Pattern | Real example | Commit |
+|---|---|---|
+| Permission/capability field not populated for this discovery path, causing false-negative gating | Android `NativeCanRead`/`NativeCanWrite` gated on `Permissions`, which Android never populates for a client-discovered descriptor — blocked every CCCD op before it was attempted | `670193a` |
+| A completion path has two ways to be satisfied (state machine vs. direct call), and only one is wired | CCCD write via `WriteValueAsync()` directly (not through `StartListeningAsync`) never resolved its own pending write | `670193a`, guard fix in `372179b` |
+| Platform stop/start API has no completion callback, so an internal flag the code waits on forever never flips | `AndroidBluetoothScanner.NativeStopAsync` never set `IsRunning = false` — `stopScan()` has no callback | `670193a` |
+| A callback's status/reason code is treated as one thing (failure) when it can also mean another (device-initiated event) | `OnConnectionStateChange` treated any non-Success as connect-failure and returned early, so a device-initiated disconnect (e.g. DFU reboot) left `IsConnected` permanently stale, then a follow-up `DisconnectAsync()` hung waiting for a callback Android will never fire again | `670193a` |
+| A cache exists at a layer below the one being bypassed | `ExploreServicesAsync(UseCache=false)` bypassed only this library's cache — Android's own GATT-stack-level cache (a rebooted DFU bootloader's stale pre-reboot services) still won this. Fix wires the already-present but dead `TryGattRefresh()` through | `23ad5f0` |
+| Edge-triggered wait misses state that changed between "caller acted" and "waiter subscribed" | `WaitForDeviceToAppearAsync` only listened to `DevicesAdded` — a fast-reappearing DFU bootloader already in the registry by subscribe-time ran the full timeout regardless | `f3f397a` |
+| A wrapper/substituted type breaks a direct cast to the platform-native delegate interface | `GetDevice(CBPeripheral)` cast straight to `ICbPeripheralDelegate`, which any `DeviceWrapper`-substituted custom device type never is | `ada1698` |
+| Exception constructor itself throws on the common case | `AppleNativeBluetoothException` did `string.Join(";", nsError.LocalizedRecoveryOptions)` — null for most `NSError`s, so constructing the exception threw instead of the real error | `ada1698` |
+| A suppression flag is checked on the wrong downstream branch | `IgnoreNextUnexpectedDisconnection` didn't gate the ERROR-level disconnect log, only a separate event further downstream — every expected DFU-reboot disconnect logged as an error anyway | `ada1698` |
+
+Open, not yet fixed — check current status before assuming otherwise:
+- OnePlus native `ScanFilter` drops every device with a scan response unless `0xFF` is in the device-type-id allow-list (`laerdal/Plugin.Bluetooth#49`).
+
+If this table grows much further, promote it into `Docs/Troubleshooting/` (or its own ADR)
+rather than letting this skill become a second copy of that folder.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "dotnet.defaultSolution": "Bluetooth.sln",
+    "dotnet.defaultSolution": "Bluetooth.slnx",
     "omnisharp.useModernNet": true,
     "dotnet.server.useOmnisharp": false,
     "files.exclude": {

--- a/Bluetooth.Abstractions.Scanning/Options/ScanningOptions.cs
+++ b/Bluetooth.Abstractions.Scanning/Options/ScanningOptions.cs
@@ -210,5 +210,25 @@ public record ScanningOptions
     /// </remarks>
     public object? Android { get; init; }
 
+    /// <summary>
+    ///     Gets the Windows platform-specific scanning options.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Should be an instance of <c>Bluetooth.Abstractions.Scanning.Options.Windows.WindowsScanningOptions</c>.
+    ///         These options are only used on Windows platforms and are ignored on other platforms.
+    ///     </para>
+    ///     <para>
+    ///         Provides access to Windows-specific scan settings such as:
+    ///     </para>
+    ///     <list type="bullet">
+    ///         <item><b>MergeScanResponses</b>: merge ADV/SCAN_RSP PDUs into one advertisement, matching Android/iOS</item>
+    ///         <item><b>ScanningMode</b>: active vs. passive scanning</item>
+    ///         <item><b>AllowExtendedAdvertisements</b>: Bluetooth 5.0+ extended advertising support</item>
+    ///         <item>Native signal strength filter knobs with no cross-platform equivalent</item>
+    ///     </list>
+    /// </remarks>
+    public object? Windows { get; init; }
+
     #endregion
 }

--- a/Bluetooth.Abstractions.Scanning/Options/Windows/WindowsScanningMode.cs
+++ b/Bluetooth.Abstractions.Scanning/Options/Windows/WindowsScanningMode.cs
@@ -1,0 +1,24 @@
+namespace Bluetooth.Abstractions.Scanning.Options.Windows;
+
+/// <summary>
+///     Windows Bluetooth LE advertisement scanning mode.
+/// </summary>
+/// <remarks>
+///     Maps to <c>Windows.Devices.Bluetooth.Advertisement.BluetoothLEScanningMode</c>.
+/// </remarks>
+public enum WindowsScanningMode
+{
+    /// <summary>
+    ///     Passive scanning: no scan request is sent, so scan-response PDUs are never solicited.
+    ///     Lowest power, but any manufacturer data that a device only advertises via scan response
+    ///     will never be observed.
+    /// </summary>
+    Passive = 0,
+
+    /// <summary>
+    ///     Active scanning: a scan request is sent to scannable advertisers, soliciting a scan
+    ///     response PDU. Required for <see cref="WindowsScanningOptions.MergeScanResponses" /> to
+    ///     have anything to merge.
+    /// </summary>
+    Active = 1
+}

--- a/Bluetooth.Abstractions.Scanning/Options/Windows/WindowsScanningOptions.cs
+++ b/Bluetooth.Abstractions.Scanning/Options/Windows/WindowsScanningOptions.cs
@@ -1,0 +1,89 @@
+namespace Bluetooth.Abstractions.Scanning.Options.Windows;
+
+/// <summary>
+///     Windows platform-specific scanning options.
+/// </summary>
+/// <remarks>
+///     These options map to <c>Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher</c>
+///     members not covered (or not fully covered) by the cross-platform <see cref="ScanningOptions" />
+///     properties. See ADR 0003 (<c>Docs/Architecture/ADR/0003-windows-scan-response-handling.md</c>)
+///     for the background on scan-response handling specifically.
+/// </remarks>
+public record WindowsScanningOptions
+{
+    /// <summary>
+    ///     Gets whether ADV and SCAN_RSP PDUs for the same advertising interval are buffered and
+    ///     merged into a single <see cref="Bluetooth.Abstractions.Scanning.IBluetoothAdvertisement" />,
+    ///     matching how Android/iOS already deliver advertisements.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Defaults to <c>false</c>: advertisements dispatch immediately with no buffering, same
+    ///         as today. Scan responses are instead dispatched separately via
+    ///         <c>WindowsBluetoothRemoteDevice.ScanResponseReceived</c> / <c>.LastScanResponse</c>,
+    ///         once the device already exists in the scanner's device list — a device is never
+    ///         created from a scan response alone.
+    ///     </para>
+    ///     <para>
+    ///         When <c>true</c>: each ADV PDU is held for up to <see cref="ScanResponseMergeWindow" />
+    ///         waiting for a matching SCAN_RSP PDU before dispatching, merging their manufacturer
+    ///         data. On timeout the advertisement fires as-is (ADV-only). <c>ScanResponseReceived</c>
+    ///         / <c>LastScanResponse</c> still fire afterward whenever a scan response was actually
+    ///         received, in both modes.
+    ///     </para>
+    ///     <para>
+    ///         Requires active scanning to ever receive anything to merge — scan responses are never
+    ///         sent to a passive scanner. See <see cref="ScanningMode" />.
+    ///     </para>
+    /// </remarks>
+    public bool MergeScanResponses { get; init; }
+
+    /// <summary>
+    ///     Gets how long to wait for a scan response before dispatching an advertisement as-is, when
+    ///     <see cref="MergeScanResponses" /> is <c>true</c>. Ignored otherwise.
+    /// </summary>
+    /// <remarks>
+    ///     Defaults to 500ms — a starting point, not yet validated against real hardware. Tune once
+    ///     tested (see ADR 0003 follow-up).
+    /// </remarks>
+    public TimeSpan ScanResponseMergeWindow { get; init; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    ///     Gets the Bluetooth LE scanning mode (active vs. passive). When <c>null</c> (default), the
+    ///     watcher keeps scanning actively, matching this plugin's existing behavior.
+    /// </summary>
+    /// <remarks>
+    ///     Takes precedence over the cross-platform <see cref="ScanningOptions.ScanMode" /> mapping
+    ///     when set. Passive scanning never solicits scan responses — incompatible with
+    ///     <see cref="MergeScanResponses" /> and with ever observing
+    ///     <c>WindowsBluetoothRemoteDevice.ScanResponseReceived</c>.
+    /// </remarks>
+    public WindowsScanningMode? ScanningMode { get; init; }
+
+    /// <summary>
+    ///     Gets whether to enable reception of advertisements using the Extended Advertising format
+    ///     (Bluetooth 5.0+, requires Windows 10 version 2004 / build 19041 or later). When
+    ///     <c>null</c> (default), falls back to the cross-platform
+    ///     <see cref="ScanningOptions.EnableExtendedAdvertising" /> value.
+    /// </summary>
+    public bool? AllowExtendedAdvertisements { get; init; }
+
+    /// <summary>
+    ///     Gets the out-of-range RSSI threshold in dBm used by the native signal strength filter. Has
+    ///     no cross-platform equivalent — <see cref="ScanningOptions.RssiThreshold" /> only ever maps
+    ///     to the native in-range threshold.
+    /// </summary>
+    public short? SignalStrengthOutOfRangeThresholdInDBm { get; init; }
+
+    /// <summary>
+    ///     Gets the sampling interval used by the native signal strength filter to aggregate RSSI
+    ///     events. Has no cross-platform equivalent.
+    /// </summary>
+    public TimeSpan? SignalStrengthSamplingInterval { get; init; }
+
+    /// <summary>
+    ///     Gets the timeout after which a device is considered out of range by the native signal
+    ///     strength filter. Has no cross-platform equivalent.
+    /// </summary>
+    public TimeSpan? SignalStrengthOutOfRangeTimeout { get; init; }
+}

--- a/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothAdvertisement.cs
+++ b/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothAdvertisement.cs
@@ -30,6 +30,44 @@ public readonly record struct WindowsBluetoothAdvertisement : IBluetoothAdvertis
         DateReceived = DateTimeOffset.UtcNow;
     }
 
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="WindowsBluetoothAdvertisement" /> struct by
+    ///     merging a primary ADV PDU with its correlated SCAN_RSP PDU, when one was received in time.
+    /// </summary>
+    /// <param name="primaryArgs">The primary (ADV) advertisement event arguments.</param>
+    /// <param name="scanResponseArgs">
+    ///     The correlated scan-response event arguments, or <c>null</c> if none arrived before the
+    ///     merge window elapsed — in which case this behaves identically to the single-argument
+    ///     constructor.
+    /// </param>
+    /// <remarks>
+    ///     Used only when <c>WindowsScanningOptions.MergeScanResponses</c> is enabled. See ADR 0003
+    ///     (<c>Docs/Architecture/ADR/0003-windows-scan-response-handling.md</c>) for the merge
+    ///     rationale and byte-layout algorithm.
+    /// </remarks>
+    public WindowsBluetoothAdvertisement(BluetoothLEAdvertisementReceivedEventArgs primaryArgs, BluetoothLEAdvertisementReceivedEventArgs? scanResponseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(primaryArgs);
+
+        var primaryName = ExtractDeviceName(primaryArgs);
+        DeviceName = !string.IsNullOrWhiteSpace(primaryName)
+            ? primaryName
+            : scanResponseArgs != null ? ExtractDeviceName(scanResponseArgs) : string.Empty;
+
+        var primaryServiceGuids = primaryArgs.Advertisement.ServiceUuids?.ToArray() ?? [];
+        ServicesGuids = primaryServiceGuids.Length > 0
+            ? primaryServiceGuids
+            : scanResponseArgs?.Advertisement.ServiceUuids?.ToArray() ?? [];
+
+        IsConnectable = primaryArgs.AdvertisementType is BluetoothLEAdvertisementType.ConnectableDirected
+            or BluetoothLEAdvertisementType.ConnectableUndirected;
+        RawSignalStrengthInDBm = primaryArgs.RawSignalStrengthInDBm;
+        TransmitPowerLevelInDBm = ExtractTransmitPowerLevel(primaryArgs);
+        BluetoothAddress = ConvertNumericBleAddressToHexBleAddress(primaryArgs.BluetoothAddress);
+        ManufacturerData = MergeManufacturerData(primaryArgs, scanResponseArgs);
+        DateReceived = DateTimeOffset.UtcNow;
+    }
+
     #region IBluetoothAdvertisement Members
 
     /// <inheritdoc />
@@ -127,7 +165,47 @@ public readonly record struct WindowsBluetoothAdvertisement : IBluetoothAdvertis
         return data;
     }
 
-    private static string ConvertNumericBleAddressToHexBleAddress(ulong bluetoothAddress)
+    /// <summary>
+    ///     Merges the manufacturer-specific-data sections of a primary ADV PDU and its correlated
+    ///     SCAN_RSP PDU, producing the same byte layout Android/iOS already deliver:
+    ///     <c>[CompanyId(2)] + [ADV payload] + [SCAN_RSP payload]</c>. The scan response's own
+    ///     redundant 2-byte company-id prefix is stripped before appending.
+    /// </summary>
+    private static ReadOnlyMemory<byte> MergeManufacturerData(BluetoothLEAdvertisementReceivedEventArgs primaryArgs, BluetoothLEAdvertisementReceivedEventArgs? scanResponseArgs)
+    {
+        var primarySection = TryGetSectionData(primaryArgs, BluetoothLEAdvertisementDataTypes.ManufacturerSpecificData);
+
+        if (scanResponseArgs == null)
+        {
+            return primarySection ?? ReadOnlyMemory<byte>.Empty;
+        }
+
+        var scanResponseSection = TryGetSectionData(scanResponseArgs, BluetoothLEAdvertisementDataTypes.ManufacturerSpecificData);
+        if (scanResponseSection == null)
+        {
+            return primarySection ?? ReadOnlyMemory<byte>.Empty;
+        }
+
+        if (primarySection == null)
+        {
+            // Nothing to prefix - the scan response's own [CompanyId][payload] stands alone.
+            return scanResponseSection;
+        }
+
+        var scanResponsePayload = scanResponseSection.Length > 2 ? scanResponseSection[2..] : Array.Empty<byte>();
+        var merged = new byte[primarySection.Length + scanResponsePayload.Length];
+        primarySection.CopyTo(merged, 0);
+        scanResponsePayload.CopyTo(merged, primarySection.Length);
+        return merged;
+    }
+
+    /// <summary>
+    ///     Converts a numeric Bluetooth LE address into its colon-separated hex string form. Exposed
+    ///     internally so <see cref="Bluetooth.Maui.Platforms.Win.Scanning.WindowsBluetoothScanner" />
+    ///     can key its pending-advertisement merge buffer without constructing a full
+    ///     <see cref="WindowsBluetoothAdvertisement" /> first.
+    /// </summary>
+    internal static string ConvertNumericBleAddressToHexBleAddress(ulong bluetoothAddress)
     {
         // Convert ulong address to hex string format (e.g., "00:11:22:33:44:55")
         var bytes = BitConverter.GetBytes(bluetoothAddress);

--- a/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothRemoteDevice.ScanResponse.cs
+++ b/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothRemoteDevice.ScanResponse.cs
@@ -1,0 +1,43 @@
+namespace Bluetooth.Maui.Platforms.Win.Scanning;
+
+public partial class WindowsBluetoothRemoteDevice
+{
+    /// <summary>
+    ///     Gets the most recent scan-response (SCAN_RSP) advertisement received for this device, if
+    ///     any.
+    /// </summary>
+    /// <remarks>
+    ///     Populated once a SCAN_RSP PDU has been correlated to this already-known device by
+    ///     <see cref="Bluetooth.Maui.Platforms.Win.Scanning.WindowsBluetoothScanner" /> — a device is
+    ///     never created from a scan response alone. Fires regardless of whether
+    ///     <c>WindowsScanningOptions.MergeScanResponses</c> is enabled; see ADR 0003
+    ///     (<c>Docs/Architecture/ADR/0003-windows-scan-response-handling.md</c>).
+    /// </remarks>
+    public WindowsBluetoothAdvertisement? LastScanResponse
+    {
+        get => GetValue<WindowsBluetoothAdvertisement?>(null);
+        private set => SetValue(value);
+    }
+
+    /// <summary>
+    ///     Occurs when a scan-response (SCAN_RSP) PDU is received for this device.
+    /// </summary>
+    public event EventHandler<AdvertisementReceivedEventArgs>? ScanResponseReceived;
+
+    /// <summary>
+    ///     Records a received scan response and raises <see cref="ScanResponseReceived" />.
+    /// </summary>
+    /// <param name="scanResponse">The scan-response advertisement received.</param>
+    internal void OnScanResponseReceived(WindowsBluetoothAdvertisement scanResponse)
+    {
+        LastScanResponse = scanResponse;
+        ScanResponseReceived?.Invoke(this, new AdvertisementReceivedEventArgs(scanResponse));
+    }
+
+    /// <inheritdoc />
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        await base.DisposeAsyncCore().ConfigureAwait(false);
+        ScanResponseReceived = null;
+    }
+}

--- a/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothRemoteDevice.cs
+++ b/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothRemoteDevice.cs
@@ -14,7 +14,7 @@ namespace Bluetooth.Maui.Platforms.Win.Scanning;
 ///     <seealso href="https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice">BluetoothLEDevice</seealso>
 ///     <seealso href="https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.genericattributeprofile.gattsession">GattSession</seealso>
 /// </remarks>
-public class WindowsBluetoothRemoteDevice : BaseBluetoothRemoteDevice, BluetoothLeDeviceProxy.IBluetoothLeDeviceProxyDelegate, NativeObjects.GattSessionWrapper.IGattSessionDelegate
+public partial class WindowsBluetoothRemoteDevice : BaseBluetoothRemoteDevice, BluetoothLeDeviceProxy.IBluetoothLeDeviceProxyDelegate, NativeObjects.GattSessionWrapper.IGattSessionDelegate
 {
     /// <summary>
     ///     Initializes a new instance of the Windows <see cref="WindowsBluetoothRemoteDevice" /> class.

--- a/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs
@@ -281,24 +281,23 @@ public class WindowsBluetoothScanner : BaseBluetoothScanner, NativeObjects.Bluet
     ///     Stops the Windows Bluetooth LE advertisement watcher and discards any advertisements still
     ///     buffered awaiting a scan response.
     /// </remarks>
-    protected override ValueTask NativeStopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+    protected async override ValueTask NativeStopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         Logger?.LogScanStopping();
         _watcher?.BluetoothLeAdvertisementWatcher.Stop();
 
-        // In-memory cleanup only (no I/O) on an infrequently-called stop path - the async
-        // alternatives these analyzers suggest buy nothing here.
-#pragma warning disable CA1849
         foreach (var hexAddress in _pendingAdvertisements.Keys.ToArray())
         {
+            // ConcurrentDictionary<TKey,TValue> has no async TryRemove overload - verified against
+            // the installed .NET 10 runtime via reflection, CA1849's suggestion here doesn't
+            // correspond to a real API. Timer does have DisposeAsync(), so that part is awaited for real.
+#pragma warning disable CA1849
             if (_pendingAdvertisements.TryRemove(hexAddress, out var pending))
+#pragma warning restore CA1849
             {
-                pending.Timer.Dispose();
+                await pending.Timer.DisposeAsync().ConfigureAwait(false);
             }
         }
-#pragma warning restore CA1849
-
-        return ValueTask.CompletedTask;
     }
 
     #endregion

--- a/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs
+++ b/Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs
@@ -27,6 +27,22 @@ public class WindowsBluetoothScanner : BaseBluetoothScanner, NativeObjects.Bluet
     private NativeObjects.BluetoothLeAdvertisementWatcherWrapper Watcher =>
         _watcher ??= new NativeObjects.BluetoothLeAdvertisementWatcherWrapper(this, _ticker);
 
+    #region Scan-Response Merging (ADR 0003)
+
+    private bool _mergeScanResponses;
+    private TimeSpan _scanResponseMergeWindow = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    ///     Primary (ADV) advertisements awaiting either a correlated scan response or their merge
+    ///     timeout, keyed by hex Bluetooth address. Only populated when
+    ///     <c>WindowsScanningOptions.MergeScanResponses</c> is enabled.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, PendingAdvertisement> _pendingAdvertisements = new();
+
+    private sealed record PendingAdvertisement(BluetoothLEAdvertisementReceivedEventArgs Args, Timer Timer);
+
+    #endregion
+
     /// <inheritdoc />
     public WindowsBluetoothScanner(IBluetoothAdapter adapter,
         IBluetoothRssiToSignalStrengthConverter rssiToSignalStrengthConverter,
@@ -49,11 +65,93 @@ public class WindowsBluetoothScanner : BaseBluetoothScanner, NativeObjects.Bluet
     ///     Called when a Bluetooth LE advertisement is received.
     /// </summary>
     /// <param name="argsAdvertisement">The advertisement event arguments.</param>
+    /// <remarks>
+    ///     See ADR 0003 (<c>Docs/Architecture/ADR/0003-windows-scan-response-handling.md</c>) for the
+    ///     full behavior this implements.
+    /// </remarks>
     public void OnAdvertisementReceived(BluetoothLEAdvertisementReceivedEventArgs argsAdvertisement)
     {
-        var advertisement = new WindowsBluetoothAdvertisement(argsAdvertisement);
+        ArgumentNullException.ThrowIfNull(argsAdvertisement);
+
+        var isScanResponse = argsAdvertisement.AdvertisementType == BluetoothLEAdvertisementType.ScanResponse;
+
+        if (!_mergeScanResponses)
+        {
+            if (isScanResponse)
+            {
+                DispatchScanResponseToExistingDevice(argsAdvertisement);
+                return;
+            }
+
+            DispatchAdvertisement(new WindowsBluetoothAdvertisement(argsAdvertisement));
+            return;
+        }
+
+        var hexAddress = WindowsBluetoothAdvertisement.ConvertNumericBleAddressToHexBleAddress(argsAdvertisement.BluetoothAddress);
+
+        if (isScanResponse)
+        {
+            if (_pendingAdvertisements.TryRemove(hexAddress, out var pending))
+            {
+                pending.Timer.Dispose();
+                DispatchAdvertisement(new WindowsBluetoothAdvertisement(pending.Args, argsAdvertisement));
+            }
+
+            // Whether or not a pending merge was resolved above, also surface the raw scan response
+            // on the device if it's already known - a late scan response (buffer already timed out)
+            // falls back to the same path used when merging is off.
+            DispatchScanResponseToExistingDevice(argsAdvertisement);
+            return;
+        }
+
+        // Primary ADV PDU: buffer it, replacing (and disposing) any stale pending entry for this
+        // address that never resolved.
+#pragma warning disable CA2000 // Stored in _pendingAdvertisements and disposed by ResolvePendingAdvertisement, the scan-response branch above, or NativeStopAsync - not leaked.
+        var timer = new Timer(_ => ResolvePendingAdvertisement(hexAddress), null, _scanResponseMergeWindow, Timeout.InfiniteTimeSpan);
+#pragma warning restore CA2000
+        var entry = new PendingAdvertisement(argsAdvertisement, timer);
+        if (_pendingAdvertisements.TryGetValue(hexAddress, out var stale))
+        {
+            stale.Timer.Dispose();
+        }
+
+        _pendingAdvertisements[hexAddress] = entry;
+    }
+
+    /// <summary>
+    ///     Fires once <see cref="Abstractions.Scanning.Options.Windows.WindowsScanningOptions.ScanResponseMergeWindow" />
+    ///     elapses for a buffered advertisement with no scan response received - dispatches it ADV-only.
+    /// </summary>
+    private void ResolvePendingAdvertisement(string hexAddress)
+    {
+        if (!_pendingAdvertisements.TryRemove(hexAddress, out var pending))
+        {
+            return; // Already resolved by a scan response arriving concurrently.
+        }
+
+        pending.Timer.Dispose();
+        DispatchAdvertisement(new WindowsBluetoothAdvertisement(pending.Args, null));
+    }
+
+    private void DispatchAdvertisement(WindowsBluetoothAdvertisement advertisement)
+    {
         Logger?.LogDeviceDiscovered(advertisement.BluetoothAddress, advertisement.RawSignalStrengthInDBm);
         OnAdvertisementReceived(advertisement); // Base class method
+    }
+
+    /// <summary>
+    ///     Correlates a scan-response PDU to an already-known device and raises
+    ///     <c>WindowsBluetoothRemoteDevice.ScanResponseReceived</c> on it. A device is never created
+    ///     from a scan response alone - if none is found for this address yet, the PDU is dropped.
+    /// </summary>
+    private void DispatchScanResponseToExistingDevice(BluetoothLEAdvertisementReceivedEventArgs scanResponseArgs)
+    {
+        var hexAddress = WindowsBluetoothAdvertisement.ConvertNumericBleAddressToHexBleAddress(scanResponseArgs.BluetoothAddress);
+
+        if (GetDeviceOrDefault(hexAddress)?.UnderlyingPlatformDevice is WindowsBluetoothRemoteDevice windowsDevice)
+        {
+            windowsDevice.OnScanResponseReceived(new WindowsBluetoothAdvertisement(scanResponseArgs));
+        }
     }
 
     /// <summary>
@@ -95,12 +193,20 @@ public class WindowsBluetoothScanner : BaseBluetoothScanner, NativeObjects.Bluet
     /// </remarks>
     protected override ValueTask NativeStartAsync(ScanningOptions scanningOptions, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
-        Logger?.LogScanStarting(scanningOptions?.ScanMode, scanningOptions?.CallbackType);
+        ArgumentNullException.ThrowIfNull(scanningOptions);
+        Logger?.LogScanStarting(scanningOptions.ScanMode, scanningOptions.CallbackType);
+
+        var windowsOptions = scanningOptions.Windows as Abstractions.Scanning.Options.Windows.WindowsScanningOptions;
+        _mergeScanResponses = windowsOptions?.MergeScanResponses ?? false;
+        _scanResponseMergeWindow = windowsOptions?.ScanResponseMergeWindow ?? TimeSpan.FromMilliseconds(500);
+
+        var nativeWatcher = Watcher.BluetoothLeAdvertisementWatcher;
+        ConfigureNativeWatcher(nativeWatcher, scanningOptions, windowsOptions);
 
         // Start watcher (status change callback will call OnStartSucceeded)
         try
         {
-            Watcher.BluetoothLeAdvertisementWatcher.Start();
+            nativeWatcher.Start();
             Logger?.LogScanStarted();
         }
         catch (COMException e)
@@ -120,14 +226,78 @@ public class WindowsBluetoothScanner : BaseBluetoothScanner, NativeObjects.Bluet
         return ValueTask.CompletedTask;
     }
 
+    /// <summary>
+    ///     Applies <see cref="ScanningOptions" /> and Windows-specific options to the native watcher
+    ///     before it starts. Covers cross-platform properties Windows already documents support for
+    ///     (<see cref="ScanningOptions.ScanMode" />, <see cref="ScanningOptions.RssiThreshold" />,
+    ///     <see cref="ScanningOptions.EnableExtendedAdvertising" />) but never previously wired up,
+    ///     plus Windows-only escape hatches with no cross-platform equivalent.
+    /// </summary>
+    private static void ConfigureNativeWatcher(BluetoothLEAdvertisementWatcher nativeWatcher, ScanningOptions scanningOptions, Abstractions.Scanning.Options.Windows.WindowsScanningOptions? windowsOptions)
+    {
+        nativeWatcher.ScanningMode = ToNativeScanningMode(windowsOptions?.ScanningMode, scanningOptions.ScanMode);
+
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 19041))
+        {
+            nativeWatcher.AllowExtendedAdvertisements = windowsOptions?.AllowExtendedAdvertisements ?? scanningOptions.EnableExtendedAdvertising;
+        }
+
+        // Always reassign (rather than only when a value is set) so a filter configured on a
+        // previous StartScanningAsync call doesn't linger once options no longer request it - the
+        // native watcher instance is created once and reused across start/stop cycles.
+        nativeWatcher.SignalStrengthFilter = new BluetoothSignalStrengthFilter
+        {
+            InRangeThresholdInDBm = scanningOptions.RssiThreshold.HasValue ? (short) scanningOptions.RssiThreshold.Value : null,
+            OutOfRangeThresholdInDBm = windowsOptions?.SignalStrengthOutOfRangeThresholdInDBm,
+            SamplingInterval = windowsOptions?.SignalStrengthSamplingInterval,
+            OutOfRangeTimeout = windowsOptions?.SignalStrengthOutOfRangeTimeout
+        };
+    }
+
+    /// <summary>
+    ///     Maps the Windows-specific <see cref="Abstractions.Scanning.Options.Windows.WindowsScanningMode" />
+    ///     escape hatch (when set) or the cross-platform <see cref="BluetoothScanMode" /> to a native
+    ///     scanning mode. Active scanning
+    ///     is preserved as the default for <see cref="BluetoothScanMode.Balanced" /> to match this
+    ///     plugin's existing (pre-ADR-0003) behavior. <see cref="BluetoothScanMode.LowPower" /> trades
+    ///     away scan-response reception entirely for reduced radio activity.
+    /// </summary>
+    private static BluetoothLEScanningMode ToNativeScanningMode(Abstractions.Scanning.Options.Windows.WindowsScanningMode? windowsScanningMode, BluetoothScanMode crossPlatformScanMode)
+    {
+        if (windowsScanningMode.HasValue)
+        {
+            return windowsScanningMode.Value == Abstractions.Scanning.Options.Windows.WindowsScanningMode.Passive
+                ? BluetoothLEScanningMode.Passive
+                : BluetoothLEScanningMode.Active;
+        }
+
+        return crossPlatformScanMode == BluetoothScanMode.LowPower
+            ? BluetoothLEScanningMode.Passive
+            : BluetoothLEScanningMode.Active;
+    }
+
     /// <inheritdoc />
     /// <remarks>
-    ///     Stops the Windows Bluetooth LE advertisement watcher.
+    ///     Stops the Windows Bluetooth LE advertisement watcher and discards any advertisements still
+    ///     buffered awaiting a scan response.
     /// </remarks>
     protected override ValueTask NativeStopAsync(TimeSpan? timeout = null, CancellationToken cancellationToken = default)
     {
         Logger?.LogScanStopping();
         _watcher?.BluetoothLeAdvertisementWatcher.Stop();
+
+        // In-memory cleanup only (no I/O) on an infrequently-called stop path - the async
+        // alternatives these analyzers suggest buy nothing here.
+#pragma warning disable CA1849
+        foreach (var hexAddress in _pendingAdvertisements.Keys.ToArray())
+        {
+            if (_pendingAdvertisements.TryRemove(hexAddress, out var pending))
+            {
+                pending.Timer.Dispose();
+            }
+        }
+#pragma warning restore CA1849
+
         return ValueTask.CompletedTask;
     }
 

--- a/Bluetooth.Maui.Sample.Scanner/Platforms/iOS/Info.plist
+++ b/Bluetooth.Maui.Sample.Scanner/Platforms/iOS/Info.plist
@@ -37,6 +37,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>bluetooth-central</string>
+		<string>fetch</string>
 	</array>
 </dict>
 </plist>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,236 @@
+# Changelog
+
+All notable changes to this project are documented here, newest first. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+> **Versioning note**: tags jump from `v1.0.3` straight to `v4.0.0` — there are no `v2.x` or
+> `v3.x` releases. `v4.0.0` is the architecture rewrite described below (layered
+> Abstractions/Core/Platform/Facade design, full Android/iOS/Windows implementations,
+> broadcasting, L2CAP), not a series of skipped point releases.
+
+## [Unreleased]
+
+## [4.0.16] - 2026-08-18
+
+### Fixed
+
+- Prevent stop-listening attempts on characteristics of an already-disconnected device
+- Enable reading `ManufacturerData` from scan responses; display manufacturer info in the sample app's device details page
+
+## [4.0.15] - 2026-08-18
+
+### Changed
+
+- Revived docfx generation and wired it into CI; enabled XML doc generation on all public API projects
+- Replaced the hand-written API/options reference docs with pointers into the generated API reference, removing duplication
+- Fixed pervasive drift between `Docs/` and the actual code (accuracy pass)
+
+### Fixed
+
+- Four real-hardware DFU hang bugs found during device testing: dead `TryGattRefresh()` never wired into `ExploreServicesAsync(UseCache=false)`, a CCCD write race guarded incorrectly, `WaitForDeviceToAppearAsync` missing devices already present at call time, and related Android listening-state cleanup
+- Renormalized line endings repo-wide to match `.gitattributes`
+
+### Dependencies
+
+- `Microsoft.SourceLink.GitHub` → 10.0.400, `Microsoft.CodeAnalysis.NetAnalyzers` → 10.0.400
+
+## [4.0.14] - 2026-08-11
+
+### Fixed
+
+- Sample app: added `TwoWay` bindings for the selected characteristic/service/device so navigating back and forth between pages deselects correctly
+- Android: request Bluetooth connect permission correctly and fixed a threading issue in the sample app
+
+## [4.0.13] - 2026-08-04
+
+### Docs
+
+- Added a Mermaid architecture diagram to the README
+- Corrected a stale claim about a Windows broadcasting limitation
+
+## [4.0.12] - 2026-08-03
+
+### Fixed
+
+- Android: only request the legacy `BLUETOOTH` permission below API 31; honor `CancellationToken` in permission-request methods
+
+### Dependencies
+
+- `actions/checkout` → v7, `actions/setup-dotnet` → v6, `Microsoft.CodeAnalysis.NetAnalyzers` → 10.0.302
+
+## [4.0.11] - 2026-08-03
+
+### Fixed
+
+- Resolve `DeviceWrapper`-substituted devices back to their underlying platform delegate; fixed two related disconnect-path bugs
+
+## [4.0.10] - 2026-08-03
+
+### Added
+
+- `IsSignalStrengthProbingEnabled` toggle on remote devices
+- `CleanRestartScanningAsync()` on the scanner, to recover scanning cleanly after a DFU-triggered device reboot
+
+### Fixed
+
+- iOS: match peripherals by identifier only (previously also matched on other fields, causing mismatches)
+- Windows: validate the advertisement type when constructing a device from an advertisement
+
+## [4.0.9] - 2026-07-02
+
+### Added
+
+- `DeviceWrapper` hook to customize the device instances returned by the scanner
+- Logging of discovered services during service exploration
+
+### Fixed
+
+- Log service IDs as strings consistently during service exploration
+
+## [4.0.8] - 2026-06-29
+
+### Fixed
+
+- Apple: wait for the adapter's powered-on state before starting a scan (with timeout support); throw the correct exception when scanning fails to start
+
+## [4.0.7] - 2026-06-29
+
+### Fixed
+
+- Android: gracefully handle a missing `BLUETOOTH_CONNECT` permission in the adapter's state ticker instead of throwing
+
+## [4.0.6] - 2026-05-08
+
+### Fixed
+
+- Android: build and startup issues; `AndroidBluetoothAdapter` constructor made public
+
+### Changed
+
+- Android target framework simplified to `net10.0-android`
+
+## [4.0.5] - 2026-03-31
+
+### Added
+
+- Comprehensive Bluetooth SIG service/characteristic definitions, with accompanying docs
+
+## [4.0.4] - 2026-03-29
+
+### Added
+
+- Resilient characteristic accessor extension methods
+
+### Fixed
+
+- Reading of battery and version characteristics, now falling back to sane defaults
+
+## [4.0.3] - 2026-03-26
+
+The bulk of the library's current feature set landed in this release.
+
+### Added
+
+- **Broadcasting (peripheral/GATT server role)**, fully implemented on Android, Apple, and Windows: advertising, local services/characteristics/descriptors, client subscriptions, and read/write request events with response override
+- **Facade pattern**: `Bluetooth.Maui`'s `BluetoothScanner`/`BluetoothBroadcaster` now sit in front of the platform implementations as the actual `IBluetoothScanner`/`IBluetoothBroadcaster` registered by DI (see `Docs/FACADE_PATTERN_SUMMARY.md` and the architecture ADRs)
+- **Profile system**: typed accessor/codec contracts and characteristic-listener orchestration for named services/characteristics, with the SIG battery profile registered by default
+- Device filtering by name and signal strength; closest-device scan mode and device-disappearance handling
+- Sample app: BLE broadcaster demo and write/listen "lab" pages
+- ADR-based architecture documentation, commit-message format guide, and contribution definition-of-done
+
+### Changed
+
+- Android scanning options/enums moved into `Bluetooth.Abstractions`
+- Several factory abstractions simplified or removed in favor of direct construction
+
+## [4.0.2] - 2026-02-26
+
+### Fixed
+
+- Apple: ensure Bluetooth is in the powered-on state before scanning
+
+## [4.0.1] - 2026-02-25
+
+### Added
+
+- Apple: background `bluetooth-central` mode for scanning; dedicated exceptions for missing `Info.plist` keys/background modes
+
+### Fixed
+
+- Post scanning-state notifications on the main thread; validate background modes for central/peripheral managers
+
+## [4.0.0] - 2026-02-24
+
+Architecture rewrite. `Plugin.Bluetooth` was renamed to `Bluetooth.Core` / `Bluetooth.Maui`, and
+the current layered design (Abstractions → Core → Platform implementations → `Bluetooth.Maui`
+facade) replaced the earlier structure.
+
+### Added
+
+- Full Android, iOS/macOS, and Windows implementations of scanning and GATT (read/write/notify)
+- L2CAP channel support (factory pattern; configurable MTU, timeout, read-buffer, and background-reading options) on Apple and Android
+- Configurable retry policy with exponential backoff for BLE operations
+- High-performance structured logging (`LoggerMessage` source generation) across Android, Apple, and Windows
+- Explicit Bluetooth permission handling and strategies
+- Sample app: device details, characteristics, and scanner pages with navigation
+
+### Changed
+
+- **Breaking**: renamed namespaces/projects from `Plugin.Bluetooth` to `Bluetooth.Core` / `Bluetooth.Maui`
+- Scanner/device APIs now return immutable snapshots of services and characteristics lists
+
+### Fixed
+
+- Disposed a leaked `AutoResetEvent`; removed incorrect exception filtering on multi-item checks
+
+## [1.0.3] - 2026-01-07
+
+### Added
+
+- Strict service-retrieval methods that throw instead of returning `null`
+
+## [1.0.2] - 2026-01-05
+
+### Changed
+
+- Reorganized logging package dependencies in the central package props
+
+## [1.0.1] - 2026-01-05
+
+### Docs
+
+- Added badges and the project icon to the README
+
+## [1.0.0] - 2026-01-05
+
+Initial public release.
+
+### Added
+
+- Core cross-platform BLE abstractions: scanner, device, service, characteristic, descriptor, exceptions, event args
+- Initial Android implementation (scan, connect, GATT read/write/listen) and a preliminary Windows implementation
+- Sample scanner app with navigation and exception handling
+- Standard GATT service definitions, configurable RSSI-to-signal-strength conversion, async retry helper
+
+[Unreleased]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.16...HEAD
+[4.0.16]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.15...v4.0.16
+[4.0.15]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.14...v4.0.15
+[4.0.14]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.13...v4.0.14
+[4.0.13]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.12...v4.0.13
+[4.0.12]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.11...v4.0.12
+[4.0.11]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.10...v4.0.11
+[4.0.10]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.9...v4.0.10
+[4.0.9]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.8...v4.0.9
+[4.0.8]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.7...v4.0.8
+[4.0.7]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.6...v4.0.7
+[4.0.6]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.5...v4.0.6
+[4.0.5]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.4...v4.0.5
+[4.0.4]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.3...v4.0.4
+[4.0.3]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.2...v4.0.3
+[4.0.2]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.1...v4.0.2
+[4.0.1]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v4.0.0...v4.0.1
+[4.0.0]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v1.0.3...v4.0.0
+[1.0.3]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/Laerdal/Plugin.Bluetooth/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Laerdal/Plugin.Bluetooth/releases/tag/v1.0.0

--- a/Docs/Architecture/ADR/0003-windows-scan-response-handling.md
+++ b/Docs/Architecture/ADR/0003-windows-scan-response-handling.md
@@ -1,0 +1,258 @@
+# ADR 0003: Windows Scan-Response Handling
+
+- Status: Proposed
+- Date: 2026-08-19
+- Decision Makers: François Raminosona (Software Architect)
+- Supersedes: `Laerdal/Plugin.Bluetooth` PR #47 (originally authored by David Rosenbusch, ownership
+  transferred after the abstraction-level approach was rejected — see Alternatives Considered)
+
+## Context
+
+`IBluetoothAdvertisement` is documented as a cross-platform-normalized snapshot: one event per
+discovered device per advertising interval, with a single consistent `ManufacturerData` byte
+layout. Android and iOS already deliver this correctly, but not because their advertisement
+protocol is simpler — because the OS does the merging for you:
+
+- **Android**: `AndroidBluetoothAdvertisement.ExtractManufacturerData` groups the raw scan
+  record's parts by manufacturer ID and concatenates all parts sharing that ID (ADV + SCAN_RSP)
+  into one byte array before Plugin.Bluetooth ever sees it.
+- **iOS**: CoreBluetooth does the equivalent natively. Per Laerdal's own firmware documentation
+  ([BLE Advertising In Laerdal Products - 00046845](https://laerdal.atlassian.net/wiki/spaces/BLE/pages/30572556),
+  "Scan response" section, updated at revision C.2 in 2020 specifically for this): "in iOS, the
+  scan response data may be appended directly to the normal advertisement data (without any way
+  to separate the two)."
+- **Windows**: `BluetoothLEAdvertisementWatcher.Received` fires once per PDU. A device that sends
+  a scannable primary ADV and a SCAN_RSP produces **two separate native events**, each carrying
+  only what that PDU physically contains. Nothing coalesces them.
+  `WindowsBluetoothAdvertisement.ExtractManufacturerData` already special-cases this
+  (`ConnectableUndirected` → treat as ADV's own manufacturer data; `ScanResponse` → treat as the
+  scan response's; everything else → empty) but returns only whichever half arrived, and
+  `BaseBluetoothRemoteDevice.OnAdvertisementReceived` overwrites `LastAdvertisement` wholesale —
+  no field-level merge. Whichever PDU arrives last wins; the other's fields are silently lost
+  until the next interval.
+
+The Laerdal firmware doc confirms the byte layout this needs to converge on. Normal case:
+`[CompanyId(2)] [DeviceId] [Status]` from the ADV, and separately `[CompanyId(2)] [0xFF
+scan-response-prefix] [scan response TLV payload]` from the SCAN_RSP. iOS's forced concatenation
+produces exactly `[CompanyId(2)] [DeviceId] [Status] [0xFF] [scan response payload]` — which is
+also what Android's manual grouping-and-concatenation produces. Windows is the only platform not
+producing this layout at all.
+
+This gap is what PR #47 was written against: Windows advertisements missing manufacturer data
+get dropped by advertisement filters, even from devices the filter is meant to match. David's fix
+(after the abstraction-level `CachedManufacturer` approach was rejected — see below) caches only
+the 2-byte `Manufacturer` enum on the device and backfills it into events that lack it. That
+unblocks filtering but leaves `ManufacturerData` itself fragmented — any consumer reading the full
+byte layout (e.g. `Laerdal.Bluetooth`'s `LaerdalAdvertisementExtensions.GetLittleFirmwareVersionOrDefault`,
+which needs device-type/status/sub-type/timestamp/version bytes) still silently gets `null` on
+whichever Windows event happened to be the ADV-only half.
+
+## Decision
+
+Add Windows-only, opt-in scan-response merging, scoped entirely to `Bluetooth.Maui.Platforms.Win`
+and additive to the Windows concrete types — no changes to `IBluetoothAdvertisement` or
+`IBluetoothRemoteDevice`.
+
+### New API surface
+
+- `Bluetooth.Abstractions.Scanning.Options.Windows.WindowsScanningOptions` (new record, sibling to
+  the existing `WindowsConnectionOptions`), attached via a new `ScanningOptions.Windows { get; init; }`
+  (`object?`, mirroring the existing `Android` property):
+  - `MergeScanResponses` (`bool`, default `false`)
+  - `ScanResponseMergeWindow` (`TimeSpan`, default `500ms`, confirmed as the starting point — the
+    firmware doc notes the central requests a scan response "most likely only... once", so it
+    should land within the same or very next advertising interval; adjust once tested against
+    real Laerdal hardware)
+- `WindowsBluetoothRemoteDevice.ScanResponseReceived` (event) and `.LastScanResponse` (property):
+  new members on the concrete Windows device type, following the same placement precedent as
+  `BluetoothLeDeviceProxy`/`GattSessionProxy`/`GattSessionStatus` already on that class. Suggest a
+  new partial file, `WindowsBluetoothRemoteDevice.ScanResponse.cs`, mirroring how
+  `BaseBluetoothRemoteDevice` splits concerns into `.Advertisement.cs`, `.Connection.cs`, etc.
+
+### Behavior
+
+**Both modes share one rule**: a device is never created from a SCAN_RSP alone. A scan-response
+PDU is only ever dispatched once a device already exists in the scanner's device list for that
+`BluetoothAddress` (same address-lookup pattern PR #47 already established in
+`WindowsBluetoothScanner.OnAdvertisementReceived`, resolved through `UnderlyingPlatformDevice`
+before casting to `WindowsBluetoothRemoteDevice`, consistent with how `AppleBluetoothScanner.GetDevice`
+already has to unwrap `DeviceWrapper`-substituted subtypes). If no device exists yet, the SCAN_RSP
+is dropped silently, exactly as it is today.
+
+**`MergeScanResponses = false` (default)**:
+- An ADV PDU is dispatched immediately through the existing path — no buffering, no added
+  latency, no side state. This may create the device if it's the first sighting.
+- A SCAN_RSP PDU is looked up against the device list. If the device exists, its
+  `LastScanResponse` is set and `ScanResponseReceived` fires on the device. The primary
+  `AdvertisementReceived`/`LastAdvertisement`/`ManufacturerData` pipeline is untouched — Windows
+  keeps today's ADV-only `ManufacturerData` on that side.
+- Chosen over defaulting to merge-on because it doesn't need a pending-advertisement side buffer:
+  it stays entirely inside the existing "advertisement → device creation/update" flow, using the
+  device list itself as the only piece of state to correlate against. Trade-off (deliberately
+  accepted): a consumer reading `IBluetoothAdvertisement.ManufacturerData` in a platform-agnostic
+  way gets less on Windows by default than on Android/iOS, unless it also branches on
+  `WindowsBluetoothRemoteDevice.LastScanResponse`.
+
+**`MergeScanResponses = true`**:
+- Every ADV PDU is held in a short-lived per-address pending buffer instead of dispatched
+  immediately, exactly as it is on every interval — not just first sighting — to genuinely mirror
+  Android/iOS's per-interval merged behavior.
+- The buffered advertisement resolves either when a matching SCAN_RSP arrives (matched by
+  `BluetoothAddress`) or when `ScanResponseMergeWindow` elapses, whichever is first.
+- Once resolved, it follows the **same path as the other platforms**: filter → `AdvertisementReceived`
+  → device creation/update, with `ManufacturerData` merged per the byte layout above:
+  `[CompanyId(2, from whichever PDU had it)] + [ADV's manufacturer-data payload, if any] +
+  [SCAN_RSP's manufacturer-data payload, if any]`. Other fields (`DeviceName`, `ServicesGuids`,
+  `IsConnectable`, `TransmitPowerLevelInDBm`) take the ADV PDU's values, falling back to the
+  SCAN_RSP's only if the ADV's were empty/default — the firmware doc states advertising data
+  carries manufacturing data + name, and scan response carries manufacturing data + UUID only, so
+  ADV is expected to be authoritative for those fields.
+- On timeout with no SCAN_RSP received (e.g. a non-scannable device), the advertisement fires
+  **as-is**, ADV-only — it is never held indefinitely or dropped.
+- If a SCAN_RSP genuinely arrived (not just a timeout), `ScanResponseReceived`/`LastScanResponse`
+  also fire on the device immediately afterward, same as the non-merge path — so power users get
+  both the merged, cross-platform-consistent advertisement *and* the raw scan-response payload if
+  they want to inspect it distinctly.
+- A SCAN_RSP that arrives late (after its buffer already timed out and dispatched) falls through
+  to the same "device already exists → dispatch `ScanResponseReceived`" path used when merging is
+  off. This means there is really only one additional mechanism here — the pending buffer with its
+  timeout — layered on top of behavior both modes otherwise share.
+
+### Documentation
+
+Given this is the one place Windows behaves differently from Android/iOS by design (not by gap),
+both `Docs/Core-Concepts/Advertisement.md` and `Docs/Platforms/Windows.md` must explicitly document:
+default behavior, what `MergeScanResponses`/`ScanResponseMergeWindow` change, that a device is
+never created from a scan response alone, and that a merge-mode timeout fires the advertisement
+as-is rather than dropping or blocking it.
+
+## Alternatives Considered
+
+### Alternative A: Split Android/iOS to match Windows (expose ADV vs SCAN_RSP everywhere)
+
+- Summary: Give every platform a `ScanResponseReceived` distinction, making Windows's PDU-level
+  granularity the cross-platform norm instead of an exception.
+- Pros: Faithful to Windows's native model; no correlation/buffering logic needed anywhere.
+- Cons: Android and iOS have **no API surface at all** for this distinction — there's no
+  callback, no flag, nothing to split on. Implementing it there means fabricating a distinction
+  the OS never gives you, less reliably than Option 1's bounded-wait correlation on Windows. It
+  also pushes the merge burden onto every consumer instead of centralizing it in one platform
+  folder, and is a breaking change to code (`Laerdal.Bluetooth`, `fds-mobile-app`) actively being
+  built out this quarter.
+
+### Alternative B: `CachedManufacturer` on the shared abstraction (original PR #47 approach)
+
+- Summary: Add a `CachedManufacturer` member to `IBluetoothAdvertisement` itself, with
+  Android/iOS stubbing `null`.
+- Pros: Simple, minimal diff.
+- Cons: Leaks a Windows-only PDU-plumbing workaround into the cross-platform contract every other
+  platform has to carry as dead weight. Rejected directly (2026-08-17) in favor of keeping it
+  Windows-only; David's rework already moved it off the abstraction before handing the PR over.
+  Superseded here regardless, since it only ever patched the 2-byte manufacturer enum, not the
+  full `ManufacturerData` byte layout.
+
+### Alternative C: Merge unconditionally on Windows, no opt-out
+
+- Summary: Always buffer and merge on Windows, matching Android/iOS with no `MergeScanResponses`
+  flag at all.
+- Pros: Zero platform leakage for any consumer reading `IBluetoothAdvertisement` alone; strongest
+  cross-platform parity.
+- Cons: Forces a pending-advertisement side buffer (and its added, if bounded, latency) onto every
+  Windows consumer with no escape hatch, even ones that don't care about scan-response content and
+  would prefer today's immediate-dispatch behavior. Rejected in favor of an opt-in default-off
+  flag specifically to preserve the simpler, buffer-free path as the default.
+
+## Consequences
+
+### Positive
+
+- Windows can now produce the same `ManufacturerData` byte layout as Android/iOS when
+  `MergeScanResponses = true`, matching what the firmware doc and existing `Laerdal.Bluetooth`
+  parsing code already assume.
+- No changes to `IBluetoothAdvertisement` or `IBluetoothRemoteDevice` — every addition is
+  Windows-only and additive, consistent with how `CachedManufacturer` was already redirected.
+- Default behavior is unchanged and non-breaking for existing consumers; the new behavior is
+  entirely opt-in.
+- Makes PR #47 unnecessary as a standalone fix — `ScanResponseReceived`/`LastScanResponse` covers
+  its use case more generally, and with the full byte layout rather than just the manufacturer ID.
+
+### Negative
+
+- With the default (`MergeScanResponses = false`), a consumer writing platform-agnostic code
+  against `IBluetoothAdvertisement.ManufacturerData` alone still gets less on Windows than on
+  Android/iOS unless it explicitly also reads `WindowsBluetoothRemoteDevice.LastScanResponse`.
+  Accepted trade-off, not a defect — see Decision.
+- Merge mode adds real state (a per-address pending-advertisement buffer with a timeout) and
+  bounded latency that Android/iOS don't need, confined to `Bluetooth.Maui.Platforms.Win`.
+- Two Windows-specific scanning-option surfaces now exist (`WindowsScanningOptions` here,
+  `WindowsConnectionOptions` already) — acceptable, matches the Android precedent
+  (`AndroidScanningOptions`/`AndroidConnectionOptions`) exactly.
+
+### Neutral
+
+- `ScanResponseMergeWindow`'s 500ms default is a confirmed starting point, not yet validated
+  against real hardware — expected to be tuned once tested, not a blocker to `Accepted`.
+
+## Follow-up Actions
+
+Tracked in detail in **SC-3208** (Jira) — the ADR is the decision record, SC-3208 is the work
+breakdown. Summary:
+
+- [ ] Implement `WindowsScanningOptions` (`MergeScanResponses`, `ScanResponseMergeWindow`) and wire
+      `ScanningOptions.Windows` through `WindowsBluetoothScanner`.
+- [ ] Implement the per-address pending-advertisement buffer and timeout in
+      `WindowsBluetoothScanner`/`BluetoothLeAdvertisementWatcherWrapper`.
+- [ ] Add `ScanResponseReceived`/`LastScanResponse` to `WindowsBluetoothRemoteDevice` (new
+      `WindowsBluetoothRemoteDevice.ScanResponse.cs` partial file).
+- [ ] Update `Docs/Core-Concepts/Advertisement.md` and `Docs/Platforms/Windows.md` per the
+      Documentation section above.
+- [ ] Validate `ScanResponseMergeWindow`'s default against real hardware; adjust if needed.
+- [x] PR #47 closed 2026-08-19 as superseded by this ADR (see PR comment); no branch repurposed —
+      implementation starts fresh from `main`.
+- [x] **In scope**: `ScanningOptions.ScanMode`, `.RssiThreshold`, and `.EnableExtendedAdvertising`
+      already document Windows support ("Mapped to sampling interval and signal strength filter
+      settings", "Full support via BluetoothLEAdvertisementWatcher.SignalStrengthFilter",
+      "Supported on Windows 10 version 2004+") that `WindowsBluetoothScanner.NativeStartAsync`
+      does not actually implement — it only calls `Watcher.BluetoothLeAdvertisementWatcher.Start()`
+      with no configuration, even though `BluetoothLeAdvertisementWatcherWrapper` already exposes
+      `ScanningMode`, `SignalStrengthFilter*`, and `AllowExtendedAdvertisements` as read-only
+      observables. Confirmed as part of this same body of work (Windows support in this plugin
+      hasn't been fully exercised yet and is likely under-implemented elsewhere too) — not spun
+      off separately. Wire these through, and add to `WindowsScanningOptions` while in there:
+      an explicit `ScanningMode` (Active/Passive) escape hatch, direct `SignalStrengthFilter`
+      knobs (`OutOfRangeThresholdInDBm`, `SamplingInterval`, `OutOfRangeTimeout` — `RssiThreshold`
+      only ever covers `InRangeThresholdInDBm`), and an `AllowExtendedAdvertisements` escape hatch.
+- [x] **In scope, confirmed against the current Microsoft Learn reference (2026-08-19)** — further
+      native `BluetoothLEAdvertisementWatcher`/`BluetoothLEAdvertisementFilter` capabilities with
+      no equivalent anywhere in this codebase today:
+  - `AdvertisementFilter` (`BluetoothLEAdvertisementFilter`) — native payload-section-based
+    filtering via `.Advertisement` (ServiceUuids/ManufacturerData/LocalName) and `.BytePatterns`
+    (offset-based raw byte pattern matching). Today `ScanningOptions.ServiceUuids` is filtered
+    **in software after** the advertisement is received on Windows (per the existing doc comment)
+    — this is a real opportunity to move to native/radio-level filtering instead, which would also
+    reduce the volume of PDUs the new merge-buffer has to handle.
+  - `UseHardwareFilter`, `UseCodedPhy`, `UseUncoded1MPhy`, `ScanParameters` — newer watcher
+    properties not yet described in the summary reference table; each needs its own docs lookup
+    during implementation before deciding whether/how to expose via `WindowsScanningOptions`.
+
+## References
+
+- Code references:
+  - `Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothAdvertisement.cs`
+  - `Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothScanner.cs`
+  - `Bluetooth.Maui.Platforms.Win/Scanning/NativeObjects/BluetoothLeAdvertisementWatcherWrapper.cs`
+  - `Bluetooth.Maui.Platforms.Win/Scanning/WindowsBluetoothRemoteDevice.cs`
+  - `Bluetooth.Core.Scanning/BaseBluetoothRemoteDevice.Advertisement.cs`
+  - `Bluetooth.Abstractions.Scanning/Options/ScanningOptions.cs`
+  - `Bluetooth.Abstractions.Scanning/Options/Android/AndroidScanningOptions.cs` (naming/shape precedent)
+  - `Bluetooth.Abstractions.Scanning/Options/Windows/WindowsConnectionOptions.cs` (sibling)
+  - `Laerdal.Bluetooth/LaerdalAdvertisementExtensions.cs`, `Laerdal.Bluetooth/Constants/LaerdalManufacturerDataType.cs`
+- Related docs:
+  - `Docs/Core-Concepts/Advertisement.md`
+  - `Docs/Platforms/Windows.md`
+  - Confluence: [BLE Advertising In Laerdal Products - 00046845](https://laerdal.atlassian.net/wiki/spaces/BLE/pages/30572556)
+- Related PRs/issues:
+  - `Laerdal/Plugin.Bluetooth#44` ("Fix: Enable reading ScanResponses for ManufacturerData")
+  - `Laerdal/Plugin.Bluetooth#47` ("Add manufacturer cache for Windows Scanner") — closed
+    2026-08-19, superseded by this ADR
+  - Jira **SC-3208** — implementation work breakdown for this ADR

--- a/Docs/Core-Concepts/Advertisement.md
+++ b/Docs/Core-Concepts/Advertisement.md
@@ -444,6 +444,45 @@ scanner.AdvertisementReceived += (s, args) =>
 - Not all devices provide manufacturer data
 - Check if device actually sends this information
 - Manufacturer data is optional in BLE spec
+- **Windows only**: some devices send manufacturer data in the scan-response PDU rather than the
+  primary advertisement — see [Windows-Specific: Scan Responses](#windows-specific-scan-responses)
+  below, since by default Windows does not merge the two into one `ManufacturerData` value the way
+  Android/iOS already do.
+
+## Windows-Specific: Scan Responses
+
+Android and iOS deliver one `IBluetoothAdvertisement` per advertising interval, with the OS/library
+already merging the primary advertisement (ADV) and scan-response (SCAN_RSP) payloads into a single
+`ManufacturerData` byte array. Windows does not do this by default: `BluetoothLEAdvertisementWatcher`
+fires a separate native event per PDU, so an ADV-only `WindowsBluetoothAdvertisement` and a
+SCAN_RSP-only one can arrive as two distinct `AdvertisementReceived` events for the same interval.
+
+```csharp
+await scanner.StartScanningAsync(new ScanningOptions
+{
+    Windows = new WindowsScanningOptions
+    {
+        MergeScanResponses = true,                                  // default: false
+        ScanResponseMergeWindow = TimeSpan.FromMilliseconds(500)    // default
+    }
+});
+```
+
+- **`MergeScanResponses = false` (default)**: advertisements dispatch immediately, exactly as
+  today — no added latency, no buffering. A scan response is instead delivered separately via
+  `WindowsBluetoothRemoteDevice.ScanResponseReceived` / `.LastScanResponse`, once the device
+  already exists in the scanner's device list. A device is **never** created from a scan response
+  alone.
+- **`MergeScanResponses = true`**: each ADV PDU is held for up to `ScanResponseMergeWindow` waiting
+  for its matching SCAN_RSP before dispatching a single, merged `IBluetoothAdvertisement` — matching
+  Android/iOS's `ManufacturerData` byte layout. If no scan response arrives before the window
+  elapses, the advertisement fires **as-is** (ADV-only) rather than being dropped or delayed
+  indefinitely. `ScanResponseReceived`/`LastScanResponse` still fire afterward whenever a scan
+  response actually arrived, in both modes.
+
+Either mode requires active scanning to ever observe scan responses at all — a passive scanner never
+solicits one. See the [Windows Platform Guide](../Platforms/Windows.md#scan-response-handling) for
+the full option surface and rationale (ADR 0003).
 
 ### Advertisements Not Received
 

--- a/Docs/Platforms/Windows.md
+++ b/Docs/Platforms/Windows.md
@@ -8,6 +8,7 @@ Comprehensive guide for Plugin.Bluetooth on Windows platform using Windows Runti
 - [WinRT Bluetooth Architecture](#winrt-bluetooth-architecture)
 - [Configuration](#configuration)
 - [Feature Support](#feature-support)
+- [Scan-Response Handling](#scan-response-handling)
 - [Platform Limitations](#platform-limitations)
 - [Best Practices](#best-practices)
 - [Troubleshooting](#troubleshooting)
@@ -120,8 +121,17 @@ No programmatic permission request needed (unlike Android/iOS).
 ```csharp
 var options = new ScanningOptions
 {
-    // Windows scans continuously when started
-    // No platform-specific options for Windows scanning
+    ScanMode = BluetoothScanMode.Balanced,   // maps to active scanning (see below)
+    RssiThreshold = -70,                     // maps to the native in-range RSSI threshold
+    EnableExtendedAdvertising = false,       // maps to AllowExtendedAdvertisements (Windows 10 2004+)
+    Windows = new WindowsScanningOptions
+    {
+        // See "Scan-Response Handling" below for MergeScanResponses/ScanResponseMergeWindow.
+        // Knobs with no cross-platform equivalent, forwarded straight to the native filter:
+        SignalStrengthOutOfRangeThresholdInDBm = -85,
+        SignalStrengthSamplingInterval = TimeSpan.FromSeconds(1),
+        SignalStrengthOutOfRangeTimeout = TimeSpan.FromSeconds(5)
+    }
 };
 
 await scanner.StartScanningAsync(options);
@@ -141,6 +151,12 @@ scanner.DeviceListChanged += (sender, args) =>
 - RSSI available during scan
 - Advertisement data parsing (LocalName, ServiceUUIDs, ManufacturerData)
 - Lower power consumption than Android in most cases
+- `ScanMode.LowPower` switches the native watcher to **passive** scanning — lowest power, but scan
+  responses are never solicited at all (see below). Every other `ScanMode` value scans **active**,
+  matching this plugin's existing default.
+- `ServiceUuids` scan filtering is currently performed **in software** after each advertisement is
+  received, not via the native `BluetoothLEAdvertisementWatcher.AdvertisementFilter` — tracked as a
+  follow-up (SC-3208).
 
 #### 2. Connection
 ```csharp
@@ -320,6 +336,56 @@ var mtu = device.Mtu;
 ```
 
 **Reason**: WinRT only provides RSSI during advertisement scanning, not from connected devices.
+
+## Scan-Response Handling
+
+Android and iOS deliver one `IBluetoothAdvertisement` per advertising interval, with the OS/library
+already merging the primary advertisement (ADV) and scan-response (SCAN_RSP) payloads into a single
+`ManufacturerData` byte array before this plugin ever sees it. Windows is the exception:
+`BluetoothLEAdvertisementWatcher.Received` fires once **per PDU**, so a device sending both a
+scannable ADV and a SCAN_RSP produces two separate native events instead of one merged snapshot —
+each carrying only what that specific PDU contains. See ADR 0003
+(`Docs/Architecture/ADR/0003-windows-scan-response-handling.md`) for the full background.
+
+`WindowsScanningOptions.MergeScanResponses` controls how this plugin bridges that gap:
+
+```csharp
+await scanner.StartScanningAsync(new ScanningOptions
+{
+    Windows = new WindowsScanningOptions
+    {
+        MergeScanResponses = true,                                // default: false
+        ScanResponseMergeWindow = TimeSpan.FromMilliseconds(500)   // default; tune per hardware
+    }
+});
+```
+
+| Mode | Behavior |
+| --- | --- |
+| `MergeScanResponses = false` (default) | Advertisements dispatch immediately, exactly as before this option existed — no buffering, no added latency. A scan response is delivered separately via `WindowsBluetoothRemoteDevice.ScanResponseReceived` / `.LastScanResponse`, once the device already exists in the scanner's device list. |
+| `MergeScanResponses = true` | Each ADV PDU is buffered for up to `ScanResponseMergeWindow` waiting for its matching SCAN_RSP. Once resolved (scan response arrived, or the window elapsed), it dispatches through the normal `AdvertisementReceived` path — merged if a scan response arrived, ADV-only otherwise. `ScanResponseReceived`/`LastScanResponse` still fire afterward whenever a scan response was actually received, in both modes. |
+
+**In both modes, a device is never created from a scan response alone** — a SCAN_RSP PDU for an
+address with no previously-seen ADV is silently dropped.
+
+**Requires active scanning.** Passive scanning (`WindowsScanningOptions.ScanningMode = Passive`, or
+the cross-platform `ScanningOptions.ScanMode = BluetoothScanMode.LowPower`) never solicits a scan
+response from the peripheral at all — with either set, neither merging nor
+`ScanResponseReceived` will ever have anything to report, regardless of `MergeScanResponses`.
+
+```csharp
+scanner.DeviceListChanged += (sender, args) =>
+{
+    foreach (var device in scanner.Devices.OfType<WindowsBluetoothRemoteDevice>())
+    {
+        device.ScanResponseReceived += (s, scanResponseArgs) =>
+        {
+            Console.WriteLine($"Scan response from {device.Id}: "
+                + $"{BitConverter.ToString(scanResponseArgs.Advertisement.ManufacturerData.ToArray())}");
+        };
+    }
+};
+```
 
 ## Platform Limitations
 

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -63,6 +63,7 @@ Goal of these docs:
 - [Contribution Definition of Done](Best-Practices/Contribution-DoD.md)
 - [Troubleshooting](Troubleshooting/Common-Issues.md)
 - [Debugging](Troubleshooting/Debugging.md)
+- [Changelog](../CHANGELOG.md)
 
 ## Layer Model
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dotnet add package Bluetooth.Maui
 Or via NuGet Package Manager:
 
 ```xml
-<PackageReference Include="Bluetooth.Maui" Version="1.0.0" />
+<PackageReference Include="Bluetooth.Maui" Version="4.0.16" />
 ```
 
 ## Quick Start
@@ -564,15 +564,12 @@ For issues, feature requests, or questions:
 
 ## Changelog
 
-### Recent Changes
+**v4.0.16** (Current)
 
-**v1.0.0** (Current)
+- 🐛 Fixed a stop-listening bug on already-disconnected characteristics
+- 🐛 Fixed reading `ManufacturerData` from scan responses
 
-- ✅ Windows platform implementation complete
-- ✅ Simplified exploration APIs (single method with options)
-- ✅ Modern DI registration with `AddBluetoothServices()`
-- ✅ Comprehensive XML documentation
-- ✅ Options pattern for all configuration
+See [CHANGELOG.md](CHANGELOG.md) for the full release history.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements ADR 0003 (`Docs/Architecture/ADR/0003-windows-scan-response-handling.md`): Windows fires ADV and SCAN_RSP as two separate native events instead of one merged snapshot per interval like Android/iOS already deliver, fragmenting `ManufacturerData`. Adds an opt-in `WindowsScanningOptions.MergeScanResponses` (default off, matching today's behavior) to buffer and merge them, plus `WindowsBluetoothRemoteDevice.ScanResponseReceived`/`.LastScanResponse` for the non-merge default path. Also wires up several `ScanningOptions` properties (`ScanMode`, `RssiThreshold`, `EnableExtendedAdvertising`) that were already documented as Windows-supported but never actually implemented.

**Status: in development, not yet tested on real hardware** — no Windows device available this session. Compiles clean cross-targeted from macOS (`Bluetooth.Maui.Platforms.Win` + `Bluetooth.Maui` for `net10.0-windows10.0.22621.0`, 0 warnings/0 errors), but has not run against a real BLE radio yet. Will move out of draft once validated.

## Why

See ADR 0003 for the full rationale, alternatives considered, and byte-layout algorithm. Supersedes PR #47.

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor (`refa`)
- [ ] Docs only
- [ ] CI/build/tooling

## Affected Areas

- [x] Abstractions
- [ ] Core
- [ ] Platform: Android
- [ ] Platform: iOS/macOS
- [x] Platform: Windows
- [ ] Platform: DotNetCore fallback
- [x] Facade (`Bluetooth.Maui`)
- [x] Documentation

## Behavior And Compatibility

- [x] Public API changed
- [ ] Exception behavior changed
- [ ] DI registration behavior changed
- [ ] Capability matrix impact
- [x] No externally visible behavior change

New additive API only (`ScanningOptions.Windows`, `WindowsScanningOptions`, `WindowsScanningMode`, `WindowsBluetoothRemoteDevice.ScanResponseReceived`/`.LastScanResponse`). Default behavior is unchanged for existing consumers — `MergeScanResponses` defaults to `false`.

## Platform Notes

Windows-only change. See ADR 0003 and the updated `Docs/Platforms/Windows.md` ("Scan-Response Handling" section) and `Docs/Core-Concepts/Advertisement.md` ("Windows-Specific: Scan Responses" section).

## Tests

- [ ] Unit tests added/updated
- [ ] Integration/smoke tests added/updated
- [ ] Manual platform validation performed
- [x] Not applicable (explain)

This repo has no unit test project. Validation will be manual, on real hardware, before moving out of draft — see Risks below.

Validation notes: pending — will update once tested against real Laerdal BLE devices.

## Documentation

- [x] Docs updated in same PR
- [x] Capability claims verified against implementation
- [ ] Links validated
- [x] Not applicable (explain)

## Logging / Diagnostics

- [ ] New logs added
- [x] EventId range validated
- [ ] No logging changes

Reuses existing `LogDeviceDiscovered`/`LogScanStarting` messages; no new EventIds needed.

## Risks And Follow-ups

Risk level:
- [ ] Low
- [x] Medium
- [ ] High

Known limitations or deferred follow-ups:
- Not yet validated on real hardware (tracked as the reason this stays in draft).
- `ScanResponseMergeWindow` defaults to 500ms — a starting point per the ADR, expected to be tuned once tested.
- Native `BluetoothLEAdvertisementFilter`/`BytePatterns` (radio-level filtering) intentionally deferred — interacts with scan-response merging in ways that need real-hardware verification before enabling (see ADR 0003 follow-ups).
- `UseHardwareFilter`/`UseCodedPhy`/`UseUncoded1MPhy`/`ScanParameters` deferred — gated behind Windows SDK 26100+, this project currently targets 22621.
- Full work breakdown tracked in Jira **SC-3208**.

## Checklist

- [x] I reviewed Docs/Best-Practices/Contribution-DoD.md
- [x] Commit header follows `type (scope): short imperative` and is <= 72 chars
- [x] Commit type is one of: feat, fix, refa, perf, docs, ci, chore, test, build
- [x] Commit body is 1-2 factual sentences (what/why), no emojis, refs, or co-authors
- [x] If architectural behavior changed, an ADR was added or updated under Docs/Architecture/ADR
